### PR TITLE
chore: deepmerge can be use for any type 

### DIFF
--- a/packages/core/src/Config/Config.ts
+++ b/packages/core/src/Config/Config.ts
@@ -67,7 +67,6 @@ export default class Config {
       if (config.default) {
         updateUserConfigWithKey({
           key,
-          // TODO: 确认 deepmerge 是否可应用于任何类型，不能的话还得再封一层
           value: config.default
             ? deepmerge(config.default, value || {})
             : value,


### PR DESCRIPTION
我加了一些测试验证 deepmerge 可以用在任意类型，因为是引入第三方的库，测试用例放在这个 umi 里感觉不是很好。

https://github.com/xiaohuoni/umi-next-tip-test/blob/master/deepmerge.test.js

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

```bash
$ umi-test
 PASS  ./deepmerge.test.js
  ✓ Number (6ms)
  ✓ String (1ms)
  ✓ Boolean (1ms)
  ✓ Null (1ms)
  ✓ Undefined (1ms)
  ✓ Array (1ms)
  ✓ Array[Object]
  ✓ Array[String,Object] (1ms)
  ✓ Deep Array (20ms)
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        3.219s
Ran all test suites.
✨  Done in 4.31s.
```
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
