### PR TITLE
chore: sync tnpm packages when published

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "umi-test",
     "test:coverage": "umi-test --coverage",
     "test:update": "umi-test --updateSnapshot",
+    "sync:tnpm": "node -e 'require(\"./scripts/syncTNPM\")()'",
     "update:deps": "yarn upgrade-interactive --latest"
   },
   "gitHooks": {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,6 +2,7 @@ const { yParser, execa, chalk } = require('@umijs/utils');
 const { join } = require('path');
 const { writeFileSync } = require('fs');
 const exec = require('./utils/exec');
+const syncTNPM = require('./syncTNPM');
 const getPackages = require('./utils/getPackages');
 const isNextVersion = require('./utils/isNextVersion');
 
@@ -140,6 +141,7 @@ async function release() {
     });
 
   logStep('done');
+  syncTNPM(pkgs);
 }
 
 release().catch(err => {

--- a/scripts/syncTNPM.js
+++ b/scripts/syncTNPM.js
@@ -1,0 +1,17 @@
+const { execa } = require('@umijs/utils');
+const { join } = require('path');
+const getPackages = require('./utils/getPackages');
+
+process.setMaxListeners(Infinity);
+
+module.exports = function(publishPkgs) {
+  const pkgs = (publishPkgs || getPackages()).map(
+    name => require(join(__dirname, '../packages', name, 'package.json')).name,
+  );
+  const commands = pkgs.map(pkg => {
+    const subprocess = execa('tnpm', ['sync', pkg]);
+    subprocess.stdout.pipe(process.stdout);
+    return subprocess;
+  });
+  Promise.all(commands);
+};


### PR DESCRIPTION
1. 发布时同步发布的模块
2. 执行 `npm run sync:tnpm` 同步所有的 umi 模块

![image](https://user-images.githubusercontent.com/13595509/74509137-bfef0980-4f3b-11ea-850c-6ba3c8379129.png)


3. 也可以执行 `node -e 'require("./scripts/syncTNPM")(["core"])'` 来同步某个模块

![image](https://user-images.githubusercontent.com/13595509/74508984-5cfd7280-4f3b-11ea-8a74-4d5b1c41d0ec.png)
