### PR TITLE
fix: proxy should run behind mock

### DIFF
--- a/packages/preset-built-in/src/plugins/commands/dev/mock/mock.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/mock/mock.ts
@@ -16,6 +16,10 @@ export default function(api: IApi) {
     },
   });
 
+  if (process.env.MOCK === 'none' || process.env.HTTP_MOCK === 'none') {
+    return;
+  }
+
   const registerBabel = (paths: string[]): void => {
     // babel compiler
     api.babelRegister.setOnlyMap({

--- a/packages/preset-built-in/src/plugins/commands/dev/mock/mock.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/mock/mock.ts
@@ -16,7 +16,7 @@ export default function(api: IApi) {
     },
   });
 
-  if (process.env.MOCK === 'none' || process.env.HTTP_MOCK === 'none') {
+  if (process.env.MOCK === 'none') {
     return;
   }
 


### PR DESCRIPTION
1. proxy 修复，需要在 mock 后执行
2. proxy 增加了 res header `x-real-url` ，方便排查问题
![image](https://user-images.githubusercontent.com/13595509/74514518-b1a6ea80-4f47-11ea-90e3-5fccfd8eda37.png)
3. 补充 `MOCK` 和 `HTTP_MOCK` 环境变量
