### PR TITLE
chore: e2e build test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/babel__traverse": "7.0.8",
     "@types/jest": "^25.1.1",
     "@types/node": "^13.7.1",
+    "@types/puppeteer": "^2.0.0",
     "@umijs/core": "3.0.0-beta.18",
     "@umijs/test": "3.0.0-beta.18",
     "@umijs/utils": "3.0.0-beta.18",
@@ -44,6 +45,7 @@
     "lint-staged": "^10.0.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
+    "puppeteer": "^2.1.1",
     "yorkie": "^2.0.0"
   }
 }

--- a/packages/preset-built-in/src/plugins/commands/dev/mock/createMiddleware.test.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/mock/createMiddleware.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { writeFileSync } from 'fs';
 import { Service } from '@umijs/core';
 import { Server } from '@umijs/server';
-import { winPath, portfinder } from '@umijs/utils';
+import { winPath } from '@umijs/utils';
 import got from 'got';
 import rimraf from 'rimraf';
 import createMiddleware from './createMiddleware';

--- a/test/build.e2e.ts
+++ b/test/build.e2e.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { fork } from 'child_process';
 import puppeteer, { Page } from 'puppeteer';
 import http from 'http';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { winPath, portfinder } from '@umijs/utils';
 
 export interface IOption {

--- a/test/build.e2e.ts
+++ b/test/build.e2e.ts
@@ -1,0 +1,116 @@
+import { join } from 'path';
+import { fork } from 'child_process';
+import puppeteer, { Page } from 'puppeteer';
+import http from 'http';
+import { existsSync, readdirSync } from 'fs';
+import { winPath, portfinder } from '@umijs/utils';
+
+export interface IOption {
+  page: Page;
+  host: string;
+}
+
+interface IServer {
+  [key: string]: {
+    port: number;
+    server?: any;
+  };
+}
+
+const servers = {} as IServer;
+let browser: any;
+let page: any;
+const fixtures = join(winPath(__dirname), 'fixtures');
+let dirs = readdirSync(fixtures).filter(dir => dir.charAt(0) !== '.');
+const testOnly = dirs.some(dir => /-only/.test(dir));
+if (testOnly) {
+  dirs = dirs.filter(dir => /-only/.test(dir));
+}
+dirs = dirs.filter(dir => !/^x-/.test(dir));
+
+beforeAll(async () => {
+  // 并行 build，加速 ci
+  const buildAndServePromise = dirs.map(dir => buildAndServe(dir));
+  await Promise.all(buildAndServePromise);
+
+  browser = await puppeteer.launch({
+    args: [
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--no-first-run',
+      '--no-zygote',
+      '--no-sandbox',
+    ],
+  });
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+});
+
+for (const dir of dirs) {
+  test(
+    dir,
+    async () => {
+      await require(join(fixtures, `${dir}/test`)).default({
+        page,
+        host: `http://localhost:${servers[dir].port}`,
+      } as IOption);
+    },
+    15000,
+  );
+}
+
+afterAll(done => {
+  Object.keys(servers).forEach(name => {
+    servers[name].server.close();
+  });
+  if (browser) {
+    browser.close();
+  }
+  done();
+});
+
+async function build(cwd: string, name: string) {
+  return new Promise((resolve, reject) => {
+    const umiPath = join(winPath(__dirname), '../packages/umi/bin/umi.js');
+    const env = {
+      COMPRESS: 'none',
+      PROGRESS: 'none',
+    } as any;
+    if (name.includes('app_root')) {
+      env.APP_ROOT = './root';
+    }
+    const child = fork(umiPath, ['build'], {
+      cwd,
+      env,
+    });
+    child.on('exit', code => {
+      if (code === 1) {
+        reject(new Error(`Project ${name} build failed`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function buildAndServe(name: string) {
+  const cwd = join(fixtures, name);
+  const targetDist = name.includes('app_root')
+    ? join(cwd, 'root', 'dist')
+    : join(cwd, 'dist');
+  await build(cwd, name);
+  return new Promise(resolve => {
+    portfinder.getPortPromise().then(port => {
+      servers[name] = { port };
+      servers[name].server = http.createServer((request, response) => {
+        return require('serve-static')(targetDist)(request, response);
+      });
+      servers[name].server.listen(port, () => {
+        console.log(`[${name}] Running at http://localhost:${port}`);
+        resolve();
+      });
+    });
+  });
+}

--- a/test/fixtures/normal/.umirc.ts
+++ b/test/fixtures/normal/.umirc.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'umi';
+
+export default defineConfig({
+  routes: [
+    {
+      path: '/',
+      component: '../layout/layout',
+      routes: [
+        { path: '/bar', component: './bar' },
+        { path: '/', component: './index' },
+      ]
+    },
+  ],
+  define: {
+    UMI_DEFINE: 'test'
+  }
+})

--- a/test/fixtures/normal/layout/layout.tsx
+++ b/test/fixtures/normal/layout/layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'umi';
+
+const Layout = (props) => {
+  return (
+    <div>
+      <Link to="/" id="link-index">index</Link>
+      <Link to="/bar" id="link-bar">bar</Link>
+      {props.children}
+    </div>
+  );
+};
+
+export default Layout;

--- a/test/fixtures/normal/pages/bar.tsx
+++ b/test/fixtures/normal/pages/bar.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>bar</h1>

--- a/test/fixtures/normal/pages/index.less
+++ b/test/fixtures/normal/pages/index.less
@@ -1,0 +1,3 @@
+.wrapper {
+  margin: 0 auto;
+}

--- a/test/fixtures/normal/pages/index.tsx
+++ b/test/fixtures/normal/pages/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'umi';
+import styles from './index.less';
+
+const { useState, useEffect } = React;
+
+export default (props) => {
+  console.log('props', props);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
+  return (
+    <div className={styles.wrapper}>
+      <p id="loaded">{String(loaded)}</p>
+      <p id="define">{UMI_DEFINE}</p>
+    </div>
+  )
+}

--- a/test/fixtures/normal/test.ts
+++ b/test/fixtures/normal/test.ts
@@ -1,0 +1,15 @@
+import { IOption } from '../../build.e2e';
+
+export default async function ({ page, host }: IOption) {
+  await page.goto(`${host}/`, {
+    waitUntil: 'networkidle2',
+  });
+  const { loaded, define } = await page.evaluate(
+    () => ({
+      loaded: document.getElementById('loaded').textContent,
+      define: document.getElementById('define').textContent,
+    })
+  );
+  expect(loaded).toEqual('true');
+  expect(define).toEqual('test');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,6 +2845,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+  integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -2898,6 +2903,13 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/puppeteer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-2.0.0.tgz#82c04f93367e2d3396e371a71be1167332148838"
+  integrity sha512-QPHXIcaPcijMbvizoM7PRL97Rm+aM8J2DmgTz2tt79b15PqbyeaCppYonvPLHQ/Q5ea92BUHDpv4bsqtiTy8kQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -3373,6 +3385,11 @@ agent-base@4, agent-base@^4.3.0:
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -4756,7 +4773,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -5401,7 +5418,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -6152,6 +6169,16 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
+  dependencies:
+    concat-stream "1.6.2"
+    debug "2.6.9"
+    mkdirp "0.5.1"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -6274,6 +6301,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
+  dependencies:
+    pend "~1.2.0"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -7161,6 +7195,14 @@ https-proxy-agent@^2.2.3:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -9302,7 +9344,7 @@ mime-db@1.43.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.25, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
@@ -9314,7 +9356,7 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.4:
+mime@^2.0.3, mime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -9447,7 +9489,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@*, mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -10400,6 +10442,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -11280,6 +11327,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -11361,6 +11413,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -11427,6 +11484,22 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.1.1.tgz#ccde47c2a688f131883b50f2d697bd25189da27e"
+  integrity sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==
+  dependencies:
+    "@types/mime-types" "^2.1.0"
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^4.0.0"
+    mime "^2.0.3"
+    mime-types "^2.1.25"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
@@ -12060,7 +12133,7 @@ rimraf@3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -14247,7 +14320,7 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-ws@^6.1.2:
+ws@^6.1.0, ws@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
@@ -14383,6 +14456,13 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yorkie@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
可以封成一个 `@umijs/e2e-test-utils`，考虑 `puppeteer` 要不要内置还是 `peerDeps`

使用的时候，写一个 `umi.e2e.ts`，直接运行 `umi-test` 

```js
// umi.e2e.ts
import { bootstrap } from '@umijs/e2e-test-utils';
bootstrap(['./'])
```

会读取路径下所有的 `e2e/{build|dev}/*.ts`，用户只需要在文件中写，不需要考虑启动脚本 fork 等问题：

```js
// e2e/build/bar.ts
export default async function ({ page, host }) {
 await page.goto(`${host}/`, {
    waitUntil: 'networkidle2',
  });
  const { loaded, define } = await page.evaluate(
    () => ({
      loaded: document.getElementById('loaded').textContent,
      define: document.getElementById('define').textContent,
    })
  );
  expect(loaded).toEqual('true');
  expect(define).toEqual('test');
}
```