### PR TITLE
fix: dev chunks using compiler

### DIFF
--- a/docs/plugin/api.md
+++ b/docs/plugin/api.md
@@ -506,6 +506,39 @@ api.addHTMLScript(() => {
 
 在 HTML 头部添加脚本。
 
+### modifyHTMLHeadJSFiles
+
+在 HTML 头部修改入口 js。
+
+```js
+api.chainWebpack(webpackConfig => {
+  webpackConfig.entry('mode').add(path.join(__dirname, './mode.js'));
+})
+api.modifyHTMLHeadJSFiles(headJSFiles => ['mode.js', ...headJSFiles]);
+
+// =>
+<head>
+  <script src="/mode.js"></script>
+</head>
+```
+
+### modifyHTMLJSFiles
+
+在 HTML 尾部修改入口 js。
+
+```js
+api.chainWebpack(webpackConfig => {
+  webpackConfig.entry('mode').add(path.join(__dirname, './mode.js'));
+})
+api.modifyHTMLJSFiles(jsFiles => ['mode.js', ...jsFiles]);
+
+// =>
+<body>
+  <script src="/mode.js"></script>
+  <script src="/umi.js"></script>
+</body>
+```
+
 ### modifyHTML
 
 修改 HTML，基于 [cheerio](https://github.com/cheeriojs/cheerio) 的 ast。

--- a/packages/core/src/Html/types.d.ts
+++ b/packages/core/src/Html/types.d.ts
@@ -1,11 +1,14 @@
+import 'cheerio';
 import { IConfig, IRoute } from '..';
 
 export interface IHTMLTag {
   [key: string]: string;
 }
 
+export type IGetChunkPath = (chunk: string) => string;
+
 export interface IModifyHTML {
-  (memo: any, args: any): Promise<any>;
+  (memo: CheerioStatic, args: { route?: IRoute }): Promise<any>;
 }
 
 export interface IAddHTML<T> {

--- a/packages/core/src/Html/types.d.ts
+++ b/packages/core/src/Html/types.d.ts
@@ -56,5 +56,5 @@ export interface IGetContentArgs extends IHtmlConfig {
   jsFiles?: string[];
   cssFiles?: string[];
   tplPath?: string;
-  modifyHTML?: IModifyHTML;
+  modifyHTML?: IModifyHTML<CheerioStatic>;
 }

--- a/packages/core/src/Html/types.d.ts
+++ b/packages/core/src/Html/types.d.ts
@@ -7,8 +7,8 @@ export interface IHTMLTag {
 
 export type IGetChunkPath = (chunk: string) => string;
 
-export interface IModifyHTML {
-  (memo: CheerioStatic, args: { route?: IRoute }): Promise<any>;
+export interface IModifyHTML<T> {
+  (memo: T, args: { route?: IRoute }): Promise<T>;
 }
 
 export interface IAddHTML<T> {
@@ -33,7 +33,9 @@ export interface IOpts {
   addHTMLMetas?: IAddHTML<IHTMLTag[]>;
   addHTMLLinks?: IAddHTML<Partial<HTMLLinkElement>[]>;
   addHTMLStyles?: IAddHTML<Partial<IStyle>[]>;
-  modifyHTML?: IModifyHTML;
+  modifyHTMLJSFiles: IModifyHTML<string[]>;
+  modifyHTMLHeadJSFiles: IModifyHTML<string[]>;
+  modifyHTML?: IModifyHTML<CheerioStatic>;
 }
 
 export interface ILink {

--- a/packages/preset-built-in/src/fixtures/html/.umirc.ts
+++ b/packages/preset-built-in/src/fixtures/html/.umirc.ts
@@ -26,5 +26,5 @@ export default {
   headScripts: [
     '//g.alicdn.com/ga.js',
     'console.log(3)',
-  ]
+  ],
 } as IConfig;

--- a/packages/preset-built-in/src/fixtures/html/mode.ts
+++ b/packages/preset-built-in/src/fixtures/html/mode.ts
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/preset-built-in/src/fixtures/html/plugin.ts
+++ b/packages/preset-built-in/src/fixtures/html/plugin.ts
@@ -1,0 +1,11 @@
+import { IApi } from 'umi';
+import { join } from 'path';
+
+export default (api: IApi) => {
+  api.chainWebpack(webpackConfig => {
+    webpackConfig.entry('mode-head').add(join(__dirname, `./mode.ts`));
+    webpackConfig.entry('mode').add(join(__dirname, `./mode.ts`));
+  })
+  api.modifyHTMLHeadJSFiles(headJSFiles => ['mode-head.js', ...headJSFiles]);
+  api.modifyHTMLJSFiles(jsFiles => ['mode.js', ...jsFiles]);
+}

--- a/packages/preset-built-in/src/index.test.ts
+++ b/packages/preset-built-in/src/index.test.ts
@@ -58,6 +58,7 @@ test('html', async () => {
   const cwd = join(fixtures, 'html');
   const service = new Service({
     cwd,
+    plugins: [require.resolve('./fixtures/html/plugin.ts')],
     presets: [require.resolve('./index.ts')],
   });
   await service.run({
@@ -88,6 +89,7 @@ test('html', async () => {
     ),
   ).toEqual(`.b{color:blue;}`);
   expect($('head script[src="//g.alicdn.com/ga.js"]')).toBeTruthy();
+  expect($('head script[src="/mode-head.js"]')).toBeTruthy();
   expect(
     removeSpace(
       $('head script')
@@ -100,18 +102,19 @@ test('html', async () => {
   expect(
     removeSpace(
       $('body script')
-        .eq(2)
+        .eq(3)
         .html(),
     ),
   ).toContain(`console.log(1);`);
   expect(
     removeSpace(
       $('body script')
-        .eq(3)
+        .eq(4)
         .html(),
     ),
   ).toContain(`console.log(2);`);
   expect($('body script[crossorigin="true"]').attr('src')).toEqual(
     '/custom.js',
   );
+  expect($('body script[src="/head.js"]')).toBeTruthy();
 });

--- a/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
@@ -13,7 +13,13 @@ export default ({
 }) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     async function sendHtml() {
-      const { jsFiles, cssFiles } = chunksToFiles(sharedMap.get('chunks'));
+      const defaultFiles = {
+        jsFiles: ['umi.js'],
+        cssFiles: ['umi.css'],
+      };
+      const { jsFiles, cssFiles } = sharedMap.get('chunks')
+        ? chunksToFiles(sharedMap.get('chunks'))
+        : defaultFiles;
       const html = getHtmlGenerator({ api });
       const content = await html.getContent({
         route: { path: req.path },

--- a/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
@@ -4,10 +4,16 @@ import { getHtmlGenerator, chunksToFiles } from '../htmlUtils';
 
 const ASSET_EXTNAMES = ['.ico', '.png', '.jpg', '.jpeg', '.gif', '.svg'];
 
-export default ({ api, chunksSet }: { api: IApi; chunksSet: any }) => {
+export default ({
+  api,
+  sharedMap,
+}: {
+  api: IApi;
+  sharedMap: Map<string, any>;
+}) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     async function sendHtml() {
-      const { jsFiles, cssFiles } = chunksToFiles(chunksSet.get('chunks'));
+      const { jsFiles, cssFiles } = chunksToFiles(sharedMap.get('chunks'));
       const html = getHtmlGenerator({ api });
       const content = await html.getContent({
         route: { path: req.path },

--- a/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/createRouteMiddleware.ts
@@ -1,17 +1,18 @@
 import { IApi, NextFunction, Request, Response } from '@umijs/types';
 import { extname, join } from 'path';
-import { getHtmlGenerator } from '../htmlUtils';
+import { getHtmlGenerator, chunksToFiles } from '../htmlUtils';
 
 const ASSET_EXTNAMES = ['.ico', '.png', '.jpg', '.jpeg', '.gif', '.svg'];
 
-export default ({ api }: { api: IApi }) => {
+export default ({ api, chunksSet }: { api: IApi; chunksSet: any }) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     async function sendHtml() {
+      const { jsFiles, cssFiles } = chunksToFiles(chunksSet.get('chunks'));
       const html = getHtmlGenerator({ api });
       const content = await html.getContent({
         route: { path: req.path },
-        cssFiles: ['umi.css'],
-        jsFiles: ['umi.js'],
+        cssFiles,
+        jsFiles,
       });
       res.setHeader('Content-Type', 'text/html');
       res.send(content);

--- a/packages/preset-built-in/src/plugins/commands/dev/dev.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/dev.ts
@@ -7,7 +7,8 @@ import createRouteMiddleware from './createRouteMiddleware';
 import generateFiles from '../generateFiles';
 
 export default (api: IApi) => {
-  const chunksSet = new Map();
+  // do something with data sharing
+  const sharedMap = new Map();
   const {
     env,
     cwd,
@@ -28,7 +29,7 @@ export default (api: IApi) => {
 
   api.onDevCompileDone(({ stats }) => {
     // store chunks
-    chunksSet.set('chunks', stats.compilation.chunks);
+    sharedMap.set('chunks', stats.compilation.chunks);
   });
 
   api.registerCommand({
@@ -132,7 +133,7 @@ export default (api: IApi) => {
         beforeMiddlewares,
         afterMiddlewares: [
           ...middlewares,
-          createRouteMiddleware({ api, chunksSet }),
+          createRouteMiddleware({ api, sharedMap }),
         ],
         ...(api.config.devServer || {}),
       });

--- a/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
+++ b/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
@@ -18,10 +18,10 @@ export function chunksToFiles(
   chunks.forEach(chunk => {
     const { files } = chunk;
     files.forEach(file => {
-      if (/\.js$/.test(file)) {
+      if (/\.js$/.test(file) && !file.includes('.hot-update')) {
         jsFiles.push(file);
       }
-      if (/\.css$/.test(file)) {
+      if (/\.css$/.test(file) && !file.includes('.hot-update')) {
         cssFiles.push(file);
       }
     });

--- a/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
+++ b/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
@@ -7,6 +7,7 @@ interface IGetContentArgs {
   route: IRoute;
   jsFiles?: any[];
   cssFiles?: any[];
+  headJSFiles?: any[];
 }
 
 export function chunksToFiles(
@@ -77,10 +78,29 @@ export function getHtmlGenerator({ api }: { api: IApi }): any {
         },
       });
 
+      const jsFiles = await api.applyPlugins({
+        key: 'modifyHTMLJSFiles',
+        type: api.ApplyPluginsType.modify,
+        initialValue: args.jsFiles || [],
+        args: {
+          route: args.route,
+        },
+      });
+
+      const headJSFiles = await api.applyPlugins({
+        key: 'modifyHTMLHeadJSFiles',
+        type: api.ApplyPluginsType.modify,
+        initialValue: args.headJSFiles || [],
+        args: {
+          route: args.route,
+        },
+      });
+
       return await super.getContent({
         route: args.route,
         cssFiles: args.cssFiles || [],
-        jsFiles: args.jsFiles || [],
+        headJSFiles,
+        jsFiles,
         headScripts: await applyPlugins({
           key: 'addHTMLHeadScripts',
           initialState: [

--- a/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
+++ b/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
@@ -21,7 +21,7 @@ export function chunksToFiles(
       if (/\.js$/.test(file) && !file.includes('.hot-update')) {
         jsFiles.push(file);
       }
-      if (/\.css$/.test(file) && !file.includes('.hot-update')) {
+      if (/\.css$/.test(file)) {
         cssFiles.push(file);
       }
     });

--- a/packages/preset-built-in/src/plugins/registerMethods.ts
+++ b/packages/preset-built-in/src/plugins/registerMethods.ts
@@ -29,6 +29,8 @@ export default function(api: IApi) {
     'addTmpGenerateWatcherPaths',
     'chainWebpack',
     'modifyHTML',
+    'modifyHTMLJSFiles',
+    'modifyHTMLHeadJSFiles',
     'modifyBundler',
     'modifyBundleConfigOpts',
     'modifyBundleConfig',


### PR DESCRIPTION
1. 优化 dev 使用 chunks
1. 增加 `modifyHTMLJSFiles` 和 `modifyHTMLHeadJSFiles` API，用于添加 entry chunk js 文件到 html