### PR TITLE
feat: add npmClient

### DIFF
--- a/examples/boilerplate/.umirc.ts
+++ b/examples/boilerplate/.umirc.ts
@@ -10,4 +10,5 @@ export default {
   favicon: 'https://sivers.com/favicon.ico',
   headScripts: [`console.log('head script')`],
   scripts: [`console.log('script')`],
+  npmClient: 'pnpm',
 };

--- a/packages/create-umi/bin/create-umi.js
+++ b/packages/create-umi/bin/create-umi.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/cli');
+require('../dist/cli');

--- a/packages/create-umi/templates/app/.npmrc.tpl
+++ b/packages/create-umi/templates/app/.npmrc.tpl
@@ -1,0 +1,1 @@
+registry={{{ registry }}}

--- a/packages/create-umi/templates/app/.umirc.ts
+++ b/packages/create-umi/templates/app/.umirc.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/packages/create-umi/templates/app/.umirc.ts.tpl
+++ b/packages/create-umi/templates/app/.umirc.ts.tpl
@@ -1,0 +1,3 @@
+export default {
+  npmClient: '{{{ npmClient }}}'
+};

--- a/packages/create-umi/templates/plugin/.npmrc.tpl
+++ b/packages/create-umi/templates/plugin/.npmrc.tpl
@@ -1,0 +1,1 @@
+registry={{{ registry }}}

--- a/packages/preset-built-in/src/features/appData/appData.ts
+++ b/packages/preset-built-in/src/features/appData/appData.ts
@@ -1,3 +1,4 @@
+import { getNpmClient } from '@umijs/utils';
 import { IApi } from '../../types';
 import { getRoutes } from '../tmpFiles/routes';
 
@@ -11,6 +12,9 @@ export default (api: IApi) => {
     });
     // hasSrcDir
     memo.hasSrcDir = api.paths.absSrcPath.endsWith('/src');
+    // npmClient
+    memo.npmClient = api.userConfig.npmClient || getNpmClient();
+
     return memo;
   });
 };

--- a/packages/preset-built-in/src/features/configPlugins/schema.ts
+++ b/packages/preset-built-in/src/features/configPlugins/schema.ts
@@ -6,5 +6,6 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     favicon: (Joi) => Joi.string(),
     headScripts: (Joi) => Joi.array().items(Joi.alternatives(Joi.string())),
     scripts: (Joi) => Joi.array().items(Joi.alternatives(Joi.string())),
+    npmClient: (Joi) => Joi.string(),
   };
 }

--- a/packages/preset-built-in/src/features/configPlugins/schema.ts
+++ b/packages/preset-built-in/src/features/configPlugins/schema.ts
@@ -1,4 +1,5 @@
 import type { Root } from '@umijs/core/compiled/@hapi/joi';
+import { NpmClientEnum } from '@umijs/utils';
 
 export function getSchemas(): Record<string, (Joi: Root) => any> {
   return {
@@ -6,6 +7,13 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     favicon: (Joi) => Joi.string(),
     headScripts: (Joi) => Joi.array().items(Joi.alternatives(Joi.string())),
     scripts: (Joi) => Joi.array().items(Joi.alternatives(Joi.string())),
-    npmClient: (Joi) => Joi.string(),
+    npmClient: (Joi) =>
+      Joi.string().valid(
+        NpmClientEnum.pnpm,
+        NpmClientEnum.tnpm,
+        NpmClientEnum.cnpm,
+        NpmClientEnum.yarn,
+        NpmClientEnum.npm,
+      ),
   };
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -27,6 +27,7 @@ import installDeps from './installDeps';
 import * as logger from './logger';
 import updatePackageJSON from './updatePackageJSON';
 export * from './importLazy';
+export * from './npmClient';
 export * from './randomColor/randomColor';
 export * as register from './register';
 export * from './winPath';

--- a/packages/utils/src/npmClient.ts
+++ b/packages/utils/src/npmClient.ts
@@ -1,5 +1,12 @@
 export type NpmClient = 'npm' | 'cnpm' | 'tnpm' | 'yarn' | 'pnpm';
-
+export const npmClients = ['pnpm', 'tnpm', 'cnpm', 'yarn', 'npm'];
+export enum NpmClientEnum {
+  pnpm = 'pnpm',
+  tnpm = 'tnpm',
+  cnpm = 'cnpm',
+  yarn = 'yarn',
+  npm = 'npm',
+}
 export const getNpmClient = (): NpmClient => {
   const userAgent = process.env.npm_config_user_agent;
   if (userAgent) {

--- a/packages/utils/src/npmClient.ts
+++ b/packages/utils/src/npmClient.ts
@@ -1,0 +1,34 @@
+export type NpmClient = 'npm' | 'cnpm' | 'tnpm' | 'yarn' | 'pnpm';
+
+export const getNpmClient = (): NpmClient => {
+  const userAgent = process.env.npm_config_user_agent;
+  if (userAgent) {
+    if (userAgent.includes('cnpm')) return 'cnpm';
+    if (userAgent.includes('tnpm')) return 'tnpm';
+    if (userAgent.includes('yarn')) return 'yarn';
+    if (userAgent.includes('pnpm')) return 'pnpm';
+  }
+  return 'npm';
+};
+
+export const checkNpmClient = (npmClient: NpmClient): boolean => {
+  const userAgent = process.env.npm_config_user_agent;
+  return !!(userAgent && userAgent.includes(npmClient));
+};
+
+export const installWithNpmClient = ({
+  npmClient,
+  cwd,
+}: {
+  npmClient: NpmClient;
+  cwd?: string;
+}): void => {
+  const { spawnSync } = require('child_process');
+  const npm = spawnSync(npmClient, [npmClient === 'yarn' ? '' : 'install'], {
+    stdio: 'inherit',
+    cwd,
+  });
+  if (npm.error) {
+    throw npm.error;
+  }
+};

--- a/packages/utils/src/npmClient.ts
+++ b/packages/utils/src/npmClient.ts
@@ -3,10 +3,10 @@ export type NpmClient = 'npm' | 'cnpm' | 'tnpm' | 'yarn' | 'pnpm';
 export const getNpmClient = (): NpmClient => {
   const userAgent = process.env.npm_config_user_agent;
   if (userAgent) {
-    if (userAgent.includes('cnpm')) return 'cnpm';
+    if (userAgent.includes('pnpm')) return 'pnpm';
     if (userAgent.includes('tnpm')) return 'tnpm';
     if (userAgent.includes('yarn')) return 'yarn';
-    if (userAgent.includes('pnpm')) return 'pnpm';
+    if (userAgent.includes('cnpm')) return 'cnpm';
   }
   return 'npm';
 };


### PR DESCRIPTION
## 关于 npm client
1. type NpmClient = 'npm'l'cnpm' l'tnpm'l'yarn'l'pnpm'
2. utils 里提供 npmClient.ts，提供如下方法
3. checkNpmClient: NpmClient 检测指定的 npm client 是否可用
4. installWithNpmClient(opts: { npmClient: NpmClient}) 使用指定的 npm client 进行安装，建议调用前先调用checkNpmClient
5.getNpmClient 获取当前可用的 npm client (pnpm-tnpm-yarn-cnpm-npm)
## 配置方面
1. 新增配置 npmClient，创建脚手架时让选择，首选 pnpm，-npmrc 里的registry 也可以让选择
2. builtin 的appData.ts 里加上 memo.npmClient，优先用配置里的，没有走 utils. getNpmClient 检测获取


> 3. generator 里安装依赖时直接用 api.appData.npmClient + installWithNpimClient 的组合
>（本次 PR，没有第3点的任何代码）