### PR TITLE
feat: esbuild externals

### DIFF
--- a/packages/bundler-esbuild/src/build.test.ts
+++ b/packages/bundler-esbuild/src/build.test.ts
@@ -9,15 +9,18 @@ interface IOpts {
 const EXISTS = '1';
 
 const expects: Record<string, Function> = {
+  alias({ files }: IOpts) {
+    expect(files['index.js']).toContain(`var a = "react";`);
+    expect(files['index.js']).toContain(`var something = "happy";`);
+  },
+  externals({ files }: IOpts) {
+    expect(files['index.js']).toContain(`module.export = React;`);
+  },
   normal({ files }: IOpts) {
     expect(files['index.js']).toContain(`console.log("foooooo");`);
   },
   node_globals_polyfill({ files }: IOpts) {
     expect(files['index.js']).toContain(`console.log("__dirname", "foooooo");`);
-  },
-  alias({ files }: IOpts) {
-    expect(files['index.js']).toContain(`var a = "react";`);
-    expect(files['index.js']).toContain(`var something = "happy";`);
   },
 };
 

--- a/packages/bundler-esbuild/src/build.ts
+++ b/packages/bundler-esbuild/src/build.ts
@@ -6,6 +6,7 @@ import { rimraf } from '@umijs/utils';
 import { lessLoader } from 'esbuild-plugin-less';
 import { join } from 'path';
 import alias from './plugins/alias';
+import externals from './plugins/externals';
 import { IBabelPlugin, IConfig } from './types';
 
 interface IOpts {
@@ -39,9 +40,8 @@ export async function build(opts: IOpts) {
     metafile: true,
     plugins: [
       lessLoader(),
-      alias(
-        opts.config.alias,
-      ) /*alias(this.opts.mfsu.depConfig!.resolve!.alias)*/,
+      alias(opts.config.alias),
+      externals(opts.config.externals),
     ],
     define: {
       // __dirname sham

--- a/packages/bundler-esbuild/src/fixtures/externals/config.ts
+++ b/packages/bundler-esbuild/src/fixtures/externals/config.ts
@@ -1,0 +1,5 @@
+export default {
+  externals: {
+    react: 'React',
+  },
+};

--- a/packages/bundler-esbuild/src/fixtures/externals/index.ts
+++ b/packages/bundler-esbuild/src/fixtures/externals/index.ts
@@ -1,0 +1,3 @@
+// @ts-ignore
+import react from 'react';
+console.log(react);

--- a/packages/bundler-esbuild/src/plugins/externals.ts
+++ b/packages/bundler-esbuild/src/plugins/externals.ts
@@ -1,0 +1,22 @@
+import { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
+
+export default (options?: Record<string, string>): Plugin => {
+  return {
+    name: 'externals',
+    setup({ onLoad, onResolve }) {
+      if (!options || Object.keys(options).length === 0) {
+        return;
+      }
+      Object.keys(options).forEach((key) => {
+        onResolve({ filter: new RegExp(`^${key}$`) }, (args) => ({
+          path: args.path,
+          namespace: key,
+        }));
+        onLoad({ filter: /.*/, namespace: key }, () => ({
+          contents: `module.export=${options[key]}`,
+          loader: 'js',
+        }));
+      });
+    },
+  };
+};


### PR DESCRIPTION
增加 esbuild externals 配置
@linbudu599 思路：将配置中的包名，通过 `module.export=` 关联到 window 对象上。