### PR TITLE
fix: path error of template files on windows

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -1,3 +1,4 @@
+import { winPath } from '@umijs/utils';
 import { addParentRoute, getConventionRoutes } from '@umijs/core';
 import { existsSync } from 'fs';
 import { isAbsolute, join } from 'path';
@@ -42,7 +43,7 @@ export async function getRouteComponents(opts: {
       const path = isAbsolute(route.file)
         ? route.file
         : `${opts.prefix}${route.file}`;
-      return `'${key}': () => import('${path}'),`;
+      return `'${key}': () => import('${winPath(path)}'),`;
     })
     .join('\n');
   return `{\n${imports}\n}`;

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { winPath } from '@umijs/utils';
 import { TEMPLATES_DIR } from '../../constants';
 import { IApi } from '../../types';
 import { importsToStr } from './importsToStr';
@@ -107,7 +108,7 @@ export default (api: IApi) => {
       path: 'core/plugin.ts',
       tplPath: join(TEMPLATES_DIR, 'plugin.tpl'),
       context: {
-        plugins: plugins.map((plugin, index) => ({ index, path: plugin })),
+        plugins: plugins.map((plugin, index) => ({ index, path: winPath(plugin) })),
         validKeys: validKeys,
       },
     });


### PR DESCRIPTION

### 问题背景

windows 上 .umi 内生成的文件如下

![image](https://user-images.githubusercontent.com/18415774/141445272-5ae5b53b-a765-46e3-ae70-d65e210c0136.png)

将引发以下报错
![image](https://user-images.githubusercontent.com/18415774/141444893-829b108b-1103-4069-af45-251584dcf461.png)


### 解决方案

生成 `template` 文件部分使用 `winPath` 函数对路径类参数做处理
