### PR TITLE
fix: files lost in npm dist

### DIFF
--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
+    "compiled",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
### 问题背景
bundler-vite 包发布时未携带 compiled 导致的报错

![image](https://user-images.githubusercontent.com/18415774/141764404-a4959bee-13e5-4194-9cf2-eb0f20222463.png)

### 解决方案
bundler-vite 包中 package.json/files 字段上补充 compiled 文件夹