### PR TITLE
fix: import ws from compiled dir

### DIFF
--- a/packages/bundler-webpack/src/server/ws.ts
+++ b/packages/bundler-webpack/src/server/ws.ts
@@ -1,6 +1,6 @@
 import { chalk } from '@umijs/utils';
 import { Server } from 'http';
-import WebSocket from 'ws';
+import WebSocket from '../../compiled/ws';
 
 export function createWebSocketServer(server: Server) {
   const wss = new WebSocket.Server({


### PR DESCRIPTION
### 问题背景
`bundler-webpack` 包中 `src/server/ws.ts` 内所使用的 `ws` 为 `node_modules` 导入，且将在 `umi dev` 运行命令中被使用

但 `package.json` 中 `ws` 为 `devDependencies` 开发时依赖，造成使用时出现以下错误

![image](https://user-images.githubusercontent.com/18415774/141767102-14803b4a-2e29-4362-99e5-2df77fd13f8d.png)

### 解决方案

1. 将 `ws` 声明为 `dependencies` 运行依赖，有额外下载成本
2. `ws` 改为从 `bundler-webpack/compiled` 中导入

依赖声明中 ws 为 8.2.3 版本，看到 compiled 包内版本为 8.2.x，猜测建议方案为方案 2

