### PR TITLE
feat: add HarmonyLinkingErrorPlugin

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -11,6 +11,7 @@ import { addCopyPlugin } from './copyPlugin';
 import { addCSSRules } from './cssRules';
 import { addDefinePlugin } from './definePlugin';
 import { addFastRefreshPlugin } from './fastRefreshPlugin';
+import { addHarmonyLinkingErrorPlugin } from './harmonyLinkingErrorPlugin';
 import { addIgnorePlugin } from './ignorePlugin';
 import { addJavaScriptRules } from './javaScriptRules';
 import { addMiniCSSExtractPlugin } from './miniCSSExtractPlugin';
@@ -162,6 +163,10 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   await addCompressPlugin(applyOpts);
   // purgecss
   // await applyPurgeCSSWebpackPlugin(applyOpts);
+
+  // handle HarmonyLinkingError
+  await addHarmonyLinkingErrorPlugin(applyOpts);
+
   // analyzer
   if (opts.analyze) {
     await addBundleAnalyzerPlugin(applyOpts);

--- a/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
+++ b/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
@@ -1,4 +1,7 @@
-import { Compiler } from '@umijs/bundler-webpack/compiled/webpack';
+import {
+  Compiler,
+  NormalModule,
+} from '@umijs/bundler-webpack/compiled/webpack';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 
 interface IOpts {
@@ -13,9 +16,12 @@ class HarmonyLinkingErrorPlugin {
         if (!compilation.warnings.length) {
           return;
         }
-        const harmonyLinkingErrors = compilation.warnings.filter(
-          (w) => w.name === 'ModuleDependencyWarning',
-        );
+        const harmonyLinkingErrors = compilation.warnings.filter((w) => {
+          return (
+            w.name === 'ModuleDependencyWarning' &&
+            !(w.module as NormalModule).resource.includes('node_modules')
+          );
+        });
         if (!harmonyLinkingErrors.length) {
           return;
         }

--- a/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
+++ b/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
@@ -1,0 +1,30 @@
+import { Compiler } from '@umijs/bundler-webpack/compiled/webpack';
+import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
+
+interface IOpts {
+  config: Config;
+}
+
+class HarmonyLinkingErrorPlugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.afterCompile.tap(
+      'HarmonyLinkingErrorPlugin',
+      (compilation) => {
+        if (!compilation.warnings.length) {
+          return;
+        }
+        const harmonyLinkingErrors = compilation.warnings.filter(
+          (w) => w.name === 'ModuleDependencyWarning',
+        );
+        if (!harmonyLinkingErrors.length) {
+          return;
+        }
+        compilation.errors.push(...harmonyLinkingErrors);
+      },
+    );
+  }
+}
+export async function addHarmonyLinkingErrorPlugin(opts: IOpts) {
+  const { config } = opts;
+  config.plugin('harmony-linking-error-plugin').use(HarmonyLinkingErrorPlugin);
+}

--- a/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
+++ b/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
@@ -8,6 +8,8 @@ interface IOpts {
   config: Config;
 }
 
+const LINKING_ERROR_TAG = 'was not found in';
+
 class HarmonyLinkingErrorPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.afterCompile.tap(
@@ -19,7 +21,8 @@ class HarmonyLinkingErrorPlugin {
         const harmonyLinkingErrors = compilation.warnings.filter((w) => {
           return (
             w.name === 'ModuleDependencyWarning' &&
-            !(w.module as NormalModule).resource.includes('node_modules')
+            !(w.module as NormalModule).resource.includes('node_modules') &&
+            w.message.includes(LINKING_ERROR_TAG)
           );
         });
         if (!harmonyLinkingErrors.length) {


### PR DESCRIPTION
Related Issue：https://github.com/umijs/umi-next/issues/116
bundler-webpack
 - [x] export not found warning 如果来源是项目代码，报错 @cdllqos

```typescript
// test.ts
import { A } from './not-found';
console.log(A);
```
current behavior:
`pass build`
after pr:
throw error like this:
```bash
error - ./index.tsx:13:19-20
export 'A' (imported as 'A') was not found in './not-found' (possible exports: default)
```