### PR TITLE
fix(core): path hook should be before config hooks

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -224,6 +224,20 @@ export class Service {
       }
       this.configOnChanges[key] = config.onChange || ConfigChangeType.reload;
     }
+
+    const paths = getPaths({
+      cwd: this.cwd,
+      env: this.env,
+      prefix: this.opts.frameworkName || DEFAULT_FRAMEWORK_NAME,
+    });
+    if (this.config.outputPath) {
+      paths.absOutputPath = join(this.cwd, this.config.outputPath);
+    }
+    this.paths = await this.applyPlugins({
+      key: 'modifyPaths',
+      initialValue: paths,
+    });
+
     // setup api.config from modifyConfig and modifyDefaultConfig
     this.stage = ServiceStage.resolveConfig;
     const config = await this.applyPlugins({
@@ -237,18 +251,7 @@ export class Service {
       initialValue: this.configDefaults,
     });
     this.config = lodash.merge(defaultConfig, config) as Record<string, any>;
-    const paths = getPaths({
-      cwd: this.cwd,
-      env: this.env,
-      prefix: this.opts.frameworkName || DEFAULT_FRAMEWORK_NAME,
-    });
-    if (this.config.outputPath) {
-      paths.absOutputPath = join(this.cwd, this.config.outputPath);
-    }
-    this.paths = await this.applyPlugins({
-      key: 'modifyPaths',
-      initialValue: paths,
-    });
+
     // applyPlugin collect app data
     // TODO: some data is mutable
     this.stage = ServiceStage.collectAppData;


### PR DESCRIPTION
- [x] 如下图，modifyConfig在getPath计算之前调用，`api.paths`是空对象，导致webpack报错
```
* configuration[0].resolve.alias['@@'] should be one of these:
      [non-empty string, ...] | false | non-empty string
```
![image](https://user-images.githubusercontent.com/5997870/144072316-a180b2d3-ee2b-46af-aceb-4213c19f9072.png)
![image](https://user-images.githubusercontent.com/5997870/144076084-6269318c-b3ed-43d3-b848-5f1954660846.png)

