### PR TITLE
feat: basic esmi feature

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -35,7 +35,7 @@ interface IOpts {
 
 export class Service {
   private opts: IOpts;
-  appData: Record<string, any> = {};
+  appData: { deps?: Record<string, string>; [key: string]: any } = {};
   args: yParser.Arguments = { _: [], $0: '' };
   commands: Record<string, Command> = {};
   generators: Record<string, Generator> = {};

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -35,6 +35,7 @@
     "@umijs/utils": "4.0.0-beta.11",
     "current-script-polyfill": "1.0.0",
     "enhanced-resolve": "5.8.3",
+    "magic-string": "0.25.7",
     "path-to-regexp": "1.7.0",
     "react": "18.0.0-alpha-f2c381131-20211004",
     "react-dom": "18.0.0-alpha-f2c381131-20211004",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -45,7 +45,8 @@
     "@types/body-parser": "1.19.2",
     "@types/multer": "1.4.7",
     "body-parser": "1.19.0",
-    "multer": "1.4.3"
+    "multer": "1.4.3",
+    "vite": "2.6.13"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-umi/src/features/esmi/Service.ts
+++ b/packages/preset-umi/src/features/esmi/Service.ts
@@ -1,0 +1,92 @@
+import { axios } from '@umijs/utils';
+import type { IApi } from '../../types';
+
+export interface IImportmapData {
+  importMap: {
+    imports: Record<string, string>;
+    scopes: Record<string, any>;
+  };
+  deps: {
+    name: string;
+    version: string;
+    type: string;
+  }[];
+}
+
+export interface IPkgData {
+  pkgJsonContent: IApi['pkg'];
+  pkgInfo: {
+    name: string;
+    version: string;
+    type: 'esm';
+    exports: {
+      name: string;
+      path: string;
+      from: string;
+      deps: {
+        name: string;
+        version: string;
+        usedMap: Record<
+          string,
+          {
+            usedNamespace?: boolean;
+            usedDefault?: boolean;
+            usedNames: string[];
+          }
+        >;
+      }[];
+    }[];
+    assets: any[];
+  };
+}
+
+/**
+ * class for connect esmi server
+ */
+export default class ESMIService {
+  cdnOrigin: string = '';
+
+  constructor(opts: { cdnOrigin: string }) {
+    this.cdnOrigin = opts.cdnOrigin;
+  }
+
+  /**
+   * build importmap from deps tree
+   * @param data  package data
+   * @returns ticketId
+   */
+  async build(data: IPkgData) {
+    return axios
+      .post<{ success: boolean; data?: { ticketId?: string } }>(
+        `${this.cdnOrigin}/api/v1/esm/build`,
+        data,
+      )
+      .then((a) => a.data.data?.ticketId);
+  }
+
+  /**
+   * get importmap from deps tree
+   * @param data  package data
+   * @returns importmap
+   */
+  async getImportmap(data: IPkgData) {
+    // get the build ticket id
+    const ticketId = await this.build(data);
+    // continue to the next request after 1s
+    const next = () =>
+      new Promise<IImportmapData | undefined>((resolve) =>
+        setTimeout(() => resolve(deferrer()), 2000),
+      );
+    const deferrer = (): Promise<IImportmapData | undefined> => {
+      return axios
+        .get<{ success: boolean; data?: IImportmapData }>(
+          `${this.cdnOrigin}/api/v1/esm/importmap/${ticketId}`,
+        )
+        .then((res) => (res.data.success ? res.data.data : next()), next);
+    };
+
+    // TODO: timeout + time spend log
+
+    return deferrer();
+  }
+}

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -1,8 +1,148 @@
+import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-lexer';
+import MagicString from 'magic-string';
 import { join } from 'path';
+import type { Plugin, ResolvedConfig } from 'vite';
 import { createResolver, scan } from '../../libs/scan';
-import { IApi } from '../../types';
+import type { IApi } from '../../types';
+import Service, { IImportmapData, IPkgData } from './Service';
+
+let importmap: IImportmapData['importMap'] = { imports: {}, scopes: {} };
+
+/**
+ * esmi vite plugin
+ */
+function esmi(opts: { handleHotUpdate?: Plugin['handleHotUpdate'] }): Plugin {
+  return {
+    name: 'preset-umi:esmi',
+
+    configResolved(config: ResolvedConfig) {
+      const { include, exclude } = config.optimizeDeps;
+
+      // do not pre-compile deps which will be loaded by importmap (for top-level deps)
+      if (include?.length) {
+        config.optimizeDeps.include = include!.filter(
+          (item) => !importmap.imports[item],
+        );
+      }
+
+      // exclude pre-compile deps which within importmap by default (for nested deps)
+      config.optimizeDeps.exclude = (exclude || []).concat(
+        Object.keys(importmap.imports).filter((item) =>
+          exclude?.includes(item),
+        ),
+      );
+    },
+
+    transform(source) {
+      try {
+        // parse imports
+        const imports = parseImports(source)[0];
+        let s: InstanceType<typeof MagicString> | undefined;
+
+        // process all imports
+        imports.forEach((item) => {
+          const { n: specifier, s: start, e: end } = item;
+
+          // replace npm package to CDN url for matched imports
+          if (specifier && importmap.imports[specifier]) {
+            s ??= new MagicString(source);
+            s.overwrite(start, end, importmap.imports[specifier]);
+          }
+        });
+
+        return s?.toString() || source;
+      } catch {
+        // syntax error or non-javascript files
+        return null;
+      }
+    },
+
+    handleHotUpdate(ctx) {
+      return opts.handleHotUpdate!(ctx);
+    },
+  };
+}
+
+/**
+ * generate package data
+ * @param api   plugin api
+ */
+function generatePkgData(api: IApi): IPkgData {
+  return {
+    pkgJsonContent: {
+      dependencies: api.pkg.dependencies || {},
+      devDependencies: api.pkg.devDependencies || {},
+    },
+    pkgInfo: {
+      name: api.pkg.name as string,
+      version: api.pkg.version as string,
+      type: 'esm',
+      exports: [
+        {
+          name: 'default',
+          path: 'es/index.js',
+          from: '',
+          deps: Object.entries(api.appData.deps!).map(([name, version]) => ({
+            name,
+            version,
+            usedMap: {
+              [name]: { usedNamespace: true, usedNames: [] },
+            },
+          })),
+        },
+      ],
+      assets: [],
+    },
+  };
+}
 
 export default (api: IApi) => {
+  let service: InstanceType<typeof Service>;
+  let resolver: ReturnType<typeof createResolver>;
+
+  /**
+   * refresh importmap and save to the top-level variable
+   */
+  async function refreshImportMap() {
+    // scan and module graph
+    // TODO: module graph
+    api.appData.deps = await scan({
+      entry: join(api.paths.absTmpPath, 'umi.ts'),
+      externals: api.config.externals,
+      resolver,
+    });
+
+    // skip umi by default
+    delete api.appData.deps['umi'];
+
+    const data = generatePkgData(api);
+    const deps = data.pkgInfo.exports.reduce(
+      (r, exp) => r.concat(exp.deps.map((dep) => dep.name)),
+      [] as string[],
+    );
+    const hasNewDep = deps.some((i) => !importmap.imports[i]);
+
+    // update importmap from esm if there has new import
+    if (hasNewDep) {
+      // TODO: add local cache and restore
+      importmap = (await service.getImportmap(data))?.importMap!;
+
+      // because we will replaced package name to CDN url in vite plugin
+      // so we must append scope rules for the CDN url like the import specifier
+      // example:
+      //   origin:
+      //   { imports: { a: 'aa', b: 'bb', c: 'cc1' }, scopes: { b: { c: 'cc2' } } }
+      //   to:
+      //   { imports: { a: 'aa', b: 'bb', c: 'cc1' }, scopes: { b: { c: 'cc2' }, 'bb': { c: 'cc2' } } }
+      Object.keys(importmap.scopes || {})
+        .filter((item) => importmap.imports[item])
+        .forEach((item) => {
+          importmap.scopes[importmap.imports[item]] = importmap.scopes[item];
+        });
+    }
+  }
+
+  // describe config
   api.describe({
     key: 'esmi',
     config: {
@@ -13,25 +153,60 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
+  // check bundler type
   api.onStart(() => {
     if (!api.args.vite) {
       throw new Error(`esmi can only be used in vite mode.`);
     }
   });
 
-  // 需要在 generate 之后是因为需要先等临时文件生成
+  // collect all imports after tmp files generated
   api.onBeforeCompiler(async () => {
-    // scan and module graph
-    // TODO: module graph
     if (api.args.vite) {
-      const resolver = createResolver({
+      // init esmi service
+      service = new Service({ cdnOrigin: api.config.esmi.cdnOrigin });
+
+      // init project resolver
+      resolver = createResolver({
         alias: api.config.alias,
       });
-      api.appData.deps = await scan({
-        entry: join(api.paths.absTmpPath, 'umi.ts'),
-        externals: api.config.externals,
-        resolver,
-      });
+
+      // init importmap
+      await refreshImportMap();
     }
   });
+
+  // append ipmortmap script for HTML
+  api.modifyHTML(($) => {
+    const scp = $('<script type="importmap"></script>');
+
+    scp.html(JSON.stringify(importmap, null, 2));
+    $('head > script:eq(0)').before(scp);
+
+    // TODO: polyfill for legacy browser
+
+    return $;
+  });
+
+  if (api.args.vite) {
+    // apply esmi vite plugin
+    api.modifyViteConfig((memo) => {
+      memo.plugins = (memo.plugins || []).concat(
+        esmi({
+          handleHotUpdate: async (ctx) => {
+            ctx.file;
+
+            // TODO: incremental refresh by ctx.file
+            await refreshImportMap();
+
+            // TODO: refresh page when importmap changed
+          },
+        }),
+      );
+
+      return memo;
+    });
+  } else {
+    // TODO: webpack implementation
+  }
 };

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from '@umijs/bundler-webpack';
 import type webpack from '@umijs/bundler-webpack/compiled/webpack';
 import type WebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
+import type { InlineConfig as ViteInlineConfig } from 'vite';
 import type {
   IAdd,
   IEvent,
@@ -140,7 +141,7 @@ export type IApi = PluginAPI &
       }
     >;
     modifyViteConfig: IModify<
-      webpack.Configuration,
+      ViteInlineConfig,
       {
         env: Env;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,7 @@ importers:
       body-parser: 1.19.0
       current-script-polyfill: 1.0.0
       enhanced-resolve: 5.8.3
+      magic-string: 0.25.7
       multer: 1.4.3
       path-to-regexp: 1.7.0
       react: 18.0.0-alpha-f2c381131-20211004
@@ -510,6 +511,7 @@ importers:
       '@umijs/utils': link:../utils
       current-script-polyfill: 1.0.0
       enhanced-resolve: 5.8.3
+      magic-string: 0.25.7
       path-to-regexp: 1.7.0
       react: 18.0.0-alpha-f2c381131-20211004
       react-dom: 18.0.0-alpha-f2c381131-20211004_4dd5d306b9d43f72893e315a470a8635

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,7 @@ importers:
       react-dom: 18.0.0-alpha-f2c381131-20211004
       react-router: 6.0.2
       react-router-dom: 6.0.2
+      vite: 2.6.13
     dependencies:
       '@types/multer': 1.4.7
       '@umijs/ast': link:../ast
@@ -518,6 +519,7 @@ importers:
       '@types/body-parser': 1.19.2
       body-parser: 1.19.0
       multer: 1.4.3
+      vite: 2.6.13
 
   packages/renderer-react:
     specifiers:
@@ -13501,7 +13503,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /rsvp/4.8.5:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
@@ -15047,6 +15048,30 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+    dev: true
+
+  /vite/2.6.13:
+    resolution: {integrity: sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.13.15
+      postcss: 8.4.4
+      resolve: 1.20.0
+      rollup: 2.60.2
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /vite/2.6.14:


### PR DESCRIPTION
## Description

包含 esmi bundless CDN 接入的基础能力：
1. esmi service 请求模块
2. esmi feature 插件部分
   1. 获取、更新、插入 importmap
   2. 通过内置 vite plugin 控制 vite 的预编译行为 + 替换依赖引入为 importmap 的 CDN 地址（后续看下这步能不能拿掉）
 
**使用方式：**
在 `.umirc.ts` 里配置 `esmi: { cdnOrigin: '内部服务的地址' }` 即可

留下的 TODO，已在源码里标记：
- [ ] module graph
- [ ] add local importmap cache and restore
- [ ] polyfill for legacy browser
- [ ] incremental refresh by ctx.file in `handleHotUpdate`
- [ ] refresh page when importmap changed
- [ ] timeout + time spend log
- [ ] webpack implementation