### PR TITLE
feat: local cache & improvements for esmi

### DIFF
--- a/packages/preset-umi/src/features/esmi/Service.ts
+++ b/packages/preset-umi/src/features/esmi/Service.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
-import { axios, logger } from '@umijs/utils';
+import { axios, logger, chalk } from '@umijs/utils';
 import type { IApi } from '../../types';
 
 export interface IImportmapData {
@@ -138,9 +138,9 @@ export default class ESMIService {
     }
 
     // log dependency list
-    logger.info('\x1b[1m\x1b[32mPre-compiling dependencies on esmi:\x1b[0m');
+    logger.info(chalk.greenBright('Pre-compiling dependencies on esmi:'));
     data.pkgInfo.exports[0].deps.forEach((dep) => {
-      console.log(`  \x1b[33m${dep.name}\x1b[0m`);
+      console.log(chalk.yellow(`  ${dep.name}`));
     });
 
     // get the build ticket id

--- a/packages/preset-umi/src/features/esmi/Service.ts
+++ b/packages/preset-umi/src/features/esmi/Service.ts
@@ -1,4 +1,6 @@
-import { axios } from '@umijs/utils';
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
 import type { IApi } from '../../types';
 
 export interface IImportmapData {
@@ -45,9 +47,63 @@ export interface IPkgData {
  */
 export default class ESMIService {
   cdnOrigin: string = '';
+  cacheDir: string = '';
+  cache: Record<string, IImportmapData> = {};
 
-  constructor(opts: { cdnOrigin: string }) {
+  constructor(opts: { cdnOrigin: string; cacheDir: string }) {
     this.cdnOrigin = opts.cdnOrigin;
+    this.cacheDir = opts.cacheDir;
+
+    // restore local cache
+    const cacheFilePath = path.join(this.cacheDir, 'importmap.json');
+
+    if (fs.existsSync(cacheFilePath)) {
+      try {
+        this.cache = require(cacheFilePath);
+      } catch {
+        /* nothing */
+      }
+    }
+  }
+
+  /**
+   * get cache file path by cache key
+   * @param data  pkg data
+   */
+  static getCacheKey(data: IPkgData) {
+    const hash = createHash('md4');
+
+    hash.update(JSON.stringify(data.pkgInfo.exports));
+
+    return hash.digest('hex');
+  }
+
+  /**
+   * get importmap cache by cache key
+   * @param key cache key
+   */
+  getCache(key: string) {
+    return this.cache[key];
+  }
+
+  /**
+   * set importmap cache
+   * @param key   cache key
+   * @param data  importmap data
+   */
+  setCache(key: string, data: IImportmapData) {
+    this.cache[key] = data;
+
+    // create cache dir
+    if (!fs.existsSync(this.cacheDir)) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    }
+
+    // write cache to file system
+    fs.writeFileSync(
+      path.join(this.cacheDir, 'importmap.json'),
+      JSON.stringify(this.cache, null, 2),
+    );
   }
 
   /**
@@ -70,9 +126,17 @@ export default class ESMIService {
    * @returns importmap
    */
   async getImportmap(data: IPkgData) {
+    const cacheKey = ESMIService.getCacheKey(data);
+    const cache = this.getCache(cacheKey);
+
+    // use valid cache first
+    if (cache) {
+      return cache;
+    }
+
     // get the build ticket id
     const ticketId = await this.build(data);
-    // continue to the next request after 1s
+    // continue to the next request after 2s
     const next = () =>
       new Promise<IImportmapData | undefined>((resolve) =>
         setTimeout(() => resolve(deferrer()), 2000),
@@ -82,7 +146,15 @@ export default class ESMIService {
         .get<{ success: boolean; data?: IImportmapData }>(
           `${this.cdnOrigin}/api/v1/esm/importmap/${ticketId}`,
         )
-        .then((res) => (res.data.success ? res.data.data : next()), next);
+        .then((res) => {
+          if (res.data.success) {
+            this.setCache(cacheKey, res.data.data!);
+
+            return res.data.data;
+          }
+
+          return next();
+        }, next);
     };
 
     // TODO: timeout + time spend log

--- a/packages/preset-umi/src/features/esmi/Service.ts
+++ b/packages/preset-umi/src/features/esmi/Service.ts
@@ -131,17 +131,17 @@ export default class ESMIService {
     const cache = this.getCache(cacheKey);
     const stamp = +new Date();
 
+    // use valid cache first
+    if (cache) {
+      logger.info('ESMi cache used');
+      return cache;
+    }
+
     // log dependency list
     logger.info('\x1b[1m\x1b[32mPre-compiling dependencies on esmi:\x1b[0m');
     data.pkgInfo.exports[0].deps.forEach((dep) => {
       console.log(`  \x1b[33m${dep.name}\x1b[0m`);
     });
-
-    // use valid cache first
-    if (cache) {
-      logger.info('Done, cache used');
-      return cache;
-    }
 
     // get the build ticket id
     const ticketId = await this.build(data);

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -116,6 +116,10 @@ export default (api: IApi) => {
     // skip umi by default
     delete api.appData.deps['umi'];
 
+    // FIXME: force include react & react-dom
+    api.appData.deps['react'] = api.appData.react.version;
+    api.appData.deps['react-dom'] = api.appData.react.version;
+
     const data = generatePkgData(api);
     const deps = data.pkgInfo.exports.reduce(
       (r, exp) => r.concat(exp.deps.map((dep) => dep.name)),

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import MagicString from 'magic-string';
 import { join } from 'path';
@@ -164,7 +165,10 @@ export default (api: IApi) => {
   api.onBeforeCompiler(async () => {
     if (api.args.vite) {
       // init esmi service
-      service = new Service({ cdnOrigin: api.config.esmi.cdnOrigin });
+      service = new Service({
+        cdnOrigin: api.config.esmi.cdnOrigin,
+        cacheDir: path.join(api.cwd, '.esmi'),
+      });
 
       // init project resolver
       resolver = createResolver({

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import MagicString from 'magic-string';
 import { join } from 'path';
@@ -174,7 +173,7 @@ export default (api: IApi) => {
       // init esmi service
       service = new Service({
         cdnOrigin: api.config.esmi.cdnOrigin,
-        cacheDir: path.join(api.cwd, '.esmi'),
+        cacheDir: join(api.cwd, '.esmi'),
       });
 
       // init project resolver

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -152,7 +152,10 @@ export default (api: IApi) => {
     key: 'esmi',
     config: {
       schema(Joi) {
-        return Joi.object();
+        return Joi.object({
+          cdnOrigin: Joi.string(),
+          shimUrl: Joi.string(),
+        });
       },
     },
     enableBy: api.EnableBy.config,
@@ -190,6 +193,13 @@ export default (api: IApi) => {
 
     scp.html(JSON.stringify(importmap, null, 2));
     $('head > script:eq(0)').before(scp);
+
+    // append importmap shim script
+    if (api.config.esmi.shimUrl) {
+      $('body > script:eq(0)').before(
+        $(`<script src="${api.config.esmi.shimUrl}"></script>\n`),
+      );
+    }
 
     // preload for importmap modules
     Object.values(importmap.imports).forEach((url) => {

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -186,12 +186,15 @@ export default (api: IApi) => {
 
   // append ipmortmap script for HTML
   api.modifyHTML(($) => {
-    const scp = $('<script type="importmap"></script>');
+    const scp = $('<script type="importmap"></script>\n');
 
     scp.html(JSON.stringify(importmap, null, 2));
     $('head > script:eq(0)').before(scp);
 
-    // TODO: polyfill for legacy browser
+    // preload for importmap modules
+    Object.values(importmap.imports).forEach((url) => {
+      scp.before($(`<link rel="modulepreload" href="${url}" />\n`));
+    });
 
     return $;
   });


### PR DESCRIPTION
## Description

优化 esmi（bundless CDN）接入的能力，包含上一个 PR #204 中的部分 TODO：

1. importmap 支持本地缓存，根据 `pkgInfo` 做识别，只要依赖没有变化就优先使用缓存
2. 添加 esmi 依赖预编译的输出信息，包括预编译依赖列表以及耗时
3. 预编译强制包含 `react` 和 `react-dom`，避免出现这两个依赖版本不一致或缺失的情况
4. importmap 的 url 都预先添加 `modulepreload`
5. 支持定制 shim 脚本兼容低版本浏览器