### PR TITLE
feat(preset-umi): noshim for dev scripts in vite mode

### DIFF
--- a/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from '@umijs/bundler-webpack';
-import { createRequestHandler } from '@umijs/server';
+import { createRequestHandler, IOpts } from '@umijs/server';
 import { IApi } from '../../types';
 import { getMarkupArgs } from './getMarkupArgs';
 
@@ -16,14 +16,17 @@ window.__vite_plugin_react_preamble_installed__ = true
 export function createRouteMiddleware(opts: { api: IApi }): RequestHandler {
   return async (req, res, next) => {
     const { vite } = opts.api.args;
+    const viteScripts: IOpts['scripts'] = [
+      // add noshim attr for skip importmap shim logic for this modules
+      { content: viteRefreshScript, noshim: '' },
+      { src: '/@vite/client', noshim: '' },
+      '/.umi/umi.ts',
+    ];
     const markupArgs = await getMarkupArgs(opts);
     // @ts-ignore
     const requestHandler = await createRequestHandler({
       ...markupArgs,
-      scripts: (vite
-        ? [viteRefreshScript, '/@vite/client', '/.umi/umi.ts']
-        : ['/umi.js']
-      ).concat(markupArgs.scripts),
+      scripts: (vite ? viteScripts : ['/umi.js']).concat(markupArgs.scripts!),
       esmScript: vite,
     });
     requestHandler(req, res, next);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -6,7 +6,7 @@ import { createServerRoutes } from './routes';
 import { normalizeScripts } from './scripts';
 import { normalizeStyles } from './styles';
 
-interface IOpts {
+export interface IOpts {
   routes: Record<
     string,
     {


### PR DESCRIPTION
## Description

Vite 模式的 dev 脚本（@vite/client 等）添加 `noshim` 标记，防止被 ESMi 的 importmap shim 处理导致浏览器卡死