### PR TITLE
fix: less import alias error

### DIFF
--- a/packages/bundler-esbuild/src/build.test.ts
+++ b/packages/bundler-esbuild/src/build.test.ts
@@ -27,6 +27,7 @@ const expects: Record<string, Function> = {
   less({ files }: IOpts) {
     expect(files['index.js']).toContain(`console.log("foooooo");`);
     expect(files['index.css']).toContain(`color: red;`);
+    expect(files['index.css']).toContain(`color: blue;`);
   },
   node_globals_polyfill({ files }: IOpts) {
     expect(files['index.js']).toContain(`console.log("__dirname", "foooooo");`);

--- a/packages/bundler-esbuild/src/build.ts
+++ b/packages/bundler-esbuild/src/build.ts
@@ -45,6 +45,7 @@ export async function build(opts: IOpts) {
       less({
         modifyVars: opts.config.theme,
         javascriptEnabled: true,
+        alias: opts.config.alias,
         ...opts.config.lessLoader,
       }),
       opts.config.alias && alias(addCwdPrefix(opts.config.alias, opts.cwd)),

--- a/packages/bundler-esbuild/src/fixtures/less/config.ts
+++ b/packages/bundler-esbuild/src/fixtures/less/config.ts
@@ -1,0 +1,7 @@
+import { join } from 'path';
+
+export default {
+  alias: {
+    antd: join(__dirname, 'path'),
+  },
+};

--- a/packages/bundler-esbuild/src/fixtures/less/index.less
+++ b/packages/bundler-esbuild/src/fixtures/less/index.less
@@ -1,3 +1,5 @@
+@import '~antd/antd.less';
+
 .main {
   color: red;
 }

--- a/packages/bundler-esbuild/src/fixtures/less/index.ts
+++ b/packages/bundler-esbuild/src/fixtures/less/index.ts
@@ -1,5 +1,6 @@
 //@ts-ignore
 import styles from './index.less';
 import './index.less';
+
 console.log('foooooo');
 console.log(styles);

--- a/packages/bundler-esbuild/src/fixtures/less/path/antd.less
+++ b/packages/bundler-esbuild/src/fixtures/less/path/antd.less
@@ -1,0 +1,4 @@
+.antd {
+    color: blue;
+}
+  

--- a/packages/bundler-esbuild/src/plugins/less.ts
+++ b/packages/bundler-esbuild/src/plugins/less.ts
@@ -2,21 +2,55 @@ import { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
 import { promises as fs } from 'fs';
 import less from 'less';
 import path from 'path';
+import { sortByAffix } from '../utils/sortByAffix';
 
-export default (options: Less.Options = {}): Plugin => {
+const aliasLessImports = (ctx: string, alias: Record<string, string>) => {
+  const importRegex = /@import(?:\s+\((.*)\))?\s+['"](.*)['"]/;
+  const globalImportRegex = /@import(?:\s+\((.*)\))?\s+['"](.*)['"]/g;
+  const match = ctx.match(globalImportRegex) || [];
+  match.forEach((el) => {
+    const [imp, _, filePath] = el.match(importRegex) || [];
+    let aliaPath = filePath;
+    // ～ 写法在 esbuild 中无实际意义
+    if (filePath.startsWith('~')) {
+      aliaPath = filePath.replace('~', '');
+    }
+    const keys = sortByAffix({ arr: Object.keys(alias), affix: '$' });
+    keys.forEach(async (key) => {
+      const value = alias[key];
+      const filter = new RegExp(`^${key}`);
+      if (filter.test(aliaPath)) {
+        aliaPath = aliaPath.replace(filter, value);
+        const aliaPathUrl = path.resolve(
+          path.extname(aliaPath) ? aliaPath : `${aliaPath}.less`,
+        );
+        ctx = ctx.replace(imp, el.replace(filePath, aliaPathUrl));
+      }
+    });
+  });
+  return ctx;
+};
+
+export default (
+  options: Less.Options & { alias?: Record<string, string> } = {},
+): Plugin => {
+  const { alias, ...lessOptions } = options;
   return {
     name: 'less',
     setup({ onLoad }) {
       onLoad({ filter: /\.less$/, namespace: 'file' }, async (args) => {
-        const content = await fs.readFile(args.path, 'utf-8');
+        let content = await fs.readFile(args.path, 'utf-8');
+        if (!!alias) {
+          content = aliasLessImports(content, alias);
+        }
         const dir = path.dirname(args.path);
         const filename = path.basename(args.path);
         try {
           const result = await less.render(content, {
             filename,
             rootpath: dir,
-            ...options,
-            paths: [...(options.paths || []), dir],
+            ...lessOptions,
+            paths: [...(lessOptions.paths || []), dir],
           });
 
           return {

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -1,7 +1,6 @@
 import type { RequestHandler } from '@umijs/bundler-webpack';
 import type webpack from '@umijs/bundler-webpack/compiled/webpack';
 import type WebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
-import type { InlineConfig as ViteInlineConfig } from 'vite';
 import type {
   IAdd,
   IEvent,
@@ -12,6 +11,7 @@ import type {
 } from '@umijs/core';
 import { Env } from '@umijs/core';
 import type { CheerioAPI } from '@umijs/utils/compiled/cheerio';
+import type { InlineConfig as ViteInlineConfig } from 'vite';
 
 export type IScript =
   | Partial<{


### PR DESCRIPTION
修复 bundler-esbuild 处理 less 时，如果是 alias 的，会找不到。

比如 @import '~antd/es/style/themes/index.less'， antd 是 alias 的。