### PR TITLE
fix: less import and style lost

### DIFF
--- a/examples/bigfish/.umirc.ts
+++ b/examples/bigfish/.umirc.ts
@@ -32,4 +32,5 @@ export default {
   },
   moment2dayjs: {},
   layout: {},
+  mfsu: { esbuild: true },
 };

--- a/packages/bundler-esbuild/src/build.ts
+++ b/packages/bundler-esbuild/src/build.ts
@@ -46,6 +46,7 @@ export async function build(opts: IOpts) {
         modifyVars: opts.config.theme,
         javascriptEnabled: true,
         alias: opts.config.alias,
+        inlineStyle: opts.inlineStyle,
         ...opts.config.lessLoader,
       }),
       opts.config.alias && alias(addCwdPrefix(opts.config.alias, opts.cwd)),

--- a/packages/bundler-esbuild/src/plugins/less.ts
+++ b/packages/bundler-esbuild/src/plugins/less.ts
@@ -1,47 +1,136 @@
 import { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
+import enhancedResolve from 'enhanced-resolve';
 import { promises as fs } from 'fs';
 import less from 'less';
 import path from 'path';
 import { sortByAffix } from '../utils/sortByAffix';
 
-const aliasLessImports = (ctx: string, alias: Record<string, string>) => {
+const resolver = enhancedResolve.create({
+  mainFields: ['module', 'browser', 'main'],
+  extensions: [
+    '.json',
+    '.js',
+    '.jsx',
+    '.ts',
+    '.tsx',
+    '.cjs',
+    '.mjs',
+    '.less',
+    '.css',
+  ],
+  // TODO: support exports
+  exportsFields: [],
+});
+
+async function resolve(context: string, path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    resolver(context, path, (err: Error, result: string) =>
+      err ? reject(err) : resolve(result),
+    );
+  });
+}
+
+const aliasLessImports = async (
+  ctx: string,
+  alias: Record<string, string>,
+  importer: string,
+) => {
   const importRegex = /@import(?:\s+\((.*)\))?\s+['"](.*)['"]/;
   const globalImportRegex = /@import(?:\s+\((.*)\))?\s+['"](.*)['"]/g;
   const match = ctx.match(globalImportRegex) || [];
-  match.forEach((el) => {
+  for (const el of match) {
     const [imp, _, filePath] = el.match(importRegex) || [];
-    let aliaPath = filePath;
-    // ～ 写法在 esbuild 中无实际意义
-    if (filePath.startsWith('~')) {
-      aliaPath = filePath.replace('~', '');
+    let aliaPath = await aliasLessImportPath(filePath, alias, importer);
+    if (aliaPath) {
+      ctx = ctx.replace(imp, el.replace(filePath, aliaPath));
     }
-    const keys = sortByAffix({ arr: Object.keys(alias), affix: '$' });
-    keys.forEach(async (key) => {
-      const value = alias[key];
-      const filter = new RegExp(`^${key}`);
-      if (filter.test(aliaPath)) {
-        aliaPath = aliaPath.replace(filter, value);
-        const aliaPathUrl = path.resolve(
-          path.extname(aliaPath) ? aliaPath : `${aliaPath}.less`,
-        );
-        ctx = ctx.replace(imp, el.replace(filePath, aliaPathUrl));
-      }
-    });
-  });
+  }
   return ctx;
 };
 
+const aliasLessImportPath = async (
+  filePath: string,
+  alias: Record<string, string>,
+  importer: string,
+) => {
+  // ～ 写法在 esbuild 中无实际意义
+  let aliaPath = filePath.startsWith('~')
+    ? filePath.replace('~', '')
+    : filePath;
+  const keys = sortByAffix({ arr: Object.keys(alias), affix: '$' });
+  for (const key of keys) {
+    const value = alias[key];
+    const filter = new RegExp(`^${key}`);
+    if (filter.test(aliaPath)) {
+      aliaPath = aliaPath.replace(filter, value);
+      aliaPath = path.extname(aliaPath) ? aliaPath : `${aliaPath}.less`;
+      return await resolve(importer, aliaPath);
+    }
+  }
+  return null;
+};
+
 export default (
-  options: Less.Options & { alias?: Record<string, string> } = {},
+  options: Less.Options & {
+    alias?: Record<string, string>;
+    inlineStyle?: boolean;
+  } = {},
 ): Plugin => {
-  const { alias, ...lessOptions } = options;
+  const { alias, inlineStyle, ...lessOptions } = options;
   return {
     name: 'less',
-    setup({ onLoad }) {
-      onLoad({ filter: /\.less$/, namespace: 'file' }, async (args) => {
+    setup({ onResolve, onLoad }) {
+      onResolve({ filter: /\.less$/, namespace: 'file' }, async (args) => {
+        let filePath = args.path;
+        if (!!alias) {
+          filePath =
+            (await aliasLessImportPath(filePath, alias, args.path)) ||
+            path.resolve(
+              process.cwd(),
+              path.relative(process.cwd(), args.resolveDir),
+              args.path,
+            );
+        } else {
+          //没有别名也要对路径进行处理
+          filePath = path.resolve(
+            process.cwd(),
+            path.relative(process.cwd(), args.resolveDir),
+            args.path,
+          );
+        }
+        return {
+          path: filePath,
+          namespace: 'less-file',
+        };
+      });
+
+      onResolve({ filter: /\.less$/, namespace: 'less-file' }, (args) => {
+        return { path: args.path, namespace: 'less-content' };
+      });
+
+      onResolve(
+        { filter: /^__style_helper__$/, namespace: 'less-file' },
+        (args) => ({
+          path: args.path,
+          namespace: 'style-helper',
+          sideEffects: false,
+        }),
+      );
+
+      onLoad({ filter: /.*/, namespace: 'less-file' }, async (args) => ({
+        contents: inlineStyle
+          ? `
+          import { injectStyle } from "__style_helper__"
+          import css from ${JSON.stringify(args.path)}
+          injectStyle(css)
+        `
+          : '',
+      }));
+
+      onLoad({ filter: /\.less$/, namespace: 'less-content' }, async (args) => {
         let content = await fs.readFile(args.path, 'utf-8');
         if (!!alias) {
-          content = aliasLessImports(content, alias);
+          content = await aliasLessImports(content, alias, args.path);
         }
         const dir = path.dirname(args.path);
         const filename = path.basename(args.path);
@@ -55,7 +144,7 @@ export default (
 
           return {
             contents: result.css,
-            loader: 'css',
+            loader: 'text',
             resolveDir: dir,
           };
         } catch (error: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,9 +679,9 @@ packages:
     dependencies:
       '@ant-design/colors': 6.0.0
       '@ant-design/icons-svg': 4.2.1
-      '@babel/runtime': 7.16.0
+      '@babel/runtime': 7.16.3
       classnames: 2.3.1
-      rc-util: 5.14.0
+      rc-util: 5.16.0
 
   /@ant-design/pro-layout/6.28.1_antd@4.17.2:
     resolution: {integrity: sha512-b6mOk4tyYj9DtsE5Ar7QWBTe4dObgHk+dWskkE5/hCHYwNnKHvSn9Rsk5ap0FHqUTXsD5bHqFxTZ0tyPI7eDMg==}
@@ -2376,6 +2376,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
+    dev: false
 
   /@babel/runtime/7.16.3:
     resolution: {integrity: sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==}
@@ -12911,6 +12912,7 @@ packages:
       '@babel/runtime': 7.16.0
       react-is: 16.13.1
       shallowequal: 1.1.0
+    dev: false
 
   /rc-util/5.16.0:
     resolution: {integrity: sha512-Pp3C9WMc7LvLy/V4BtkRZRENizrbQInvy61muxsIA7beC44D1G8w6hcKrcQ4ujeZA4qhvUT0jLgOok2OhxBTRQ==}


### PR DESCRIPTION
1、修复 less 文件的 import 路径问题（包含别名和相对路径）
2、修复 esbuild less style lost 问题

```
1. examples/bigfish 下开启配置 mfsu: { esbuild: true }
2. rm -rf .mfsu && npm run dev
```
![image](https://user-images.githubusercontent.com/11746742/146511212-82bf87bb-eb06-4891-9b3e-6092e92ac5b6.png)

## 主要问题

1、esbuild 不解析 less 文件
2、less 文件的引用别名问题
3、esbuild 不加载 css 样式问题

## 解题思路

1、使用 less.render 编译 less 文件，通过自定义插件中使用的 `less.render` 就可以将 less 文件转化为 css 文件。这部分思路参考了 https://github.com/iam-medvedev/esbuild-plugin-less/blob/528414ac5d0eb6280713adc8ca33e38184628f4c/src/index.ts#L29

```ts
     onLoad({ filter: /\.less$/, namespace: 'file' }, (args) => {
        let content = await fs.readFile(args.path, 'utf-8');
        return {
          contents: less.render().css,
          loader: 'css',
          resolveDir: dir,
        };
      }
```

2、在上面的解析 less 的过程中，我们使用 `readFile` 直接读取了文件中的内容，然后通过 `less`解析，通过 `@import` 和 `less rootpath` 的规则，没有办法找到我们定义的别名（alias），所以我们需要先处理一下读取出来的字符串，将 `import` 的正确路径匹配。

```
if (!!alias) {
  content = await aliasLessImports(content, alias, args.path);
}
```

同时需要在 `onResolve` 中处理 `path` 的别名问题和相对路径问题，这里是 esbuild 的加载路径，直接加载也会导致包名报错。
```
       if (!!alias) {
          filePath =
            (await aliasLessImportPath(filePath, alias, args.path)) ||
            path.resolve(
              process.cwd(),
              path.relative(process.cwd(), args.resolveDir),
              args.path,
            );
        } else {
          //没有别名也要对路径进行处理
          filePath = path.resolve(
            process.cwd(),
            path.relative(process.cwd(), args.resolveDir),
            args.path,
          );
        }
```

3、esbuild 不加载 css 文件的问题，有许多 issues 讨论 https://github.com/evanw/esbuild/issues/20#issuecomment-802269745 

其实和自定义的 style 插件是一样的问题，所以方法类似 https://github.com/umijs/umi-next/blob/master/packages/bundler-esbuild/src/plugins/style.ts

简单的描述一下原理，相当于存在一个同名文件，替换掉原有文件，内容为

```
import css from ${JSON.stringify(args.path)}
function injectStyle(text) {
  if (typeof document !== 'undefined') {
    var style = document.createElement('style')
    var node = document.createTextNode(text)
    style.appendChild(node)
    document.head.appendChild(style)
  }
}
injectStyle(css)
```
这样 esbuild 加载它的时候，就会把 style 注入到 html 中。