### PR TITLE
feat: skipPlugin by config

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -396,6 +396,7 @@ export class Service {
     const { id, key, enableBy } = hook.plugin;
     if (this.skipPluginIds.has(id)) return false;
     if (this.userConfig[key] === false) return false;
+    if (this.config[key] === false) return false;
     if (
       enableBy === EnableBy.config &&
       // this.config is not ready when modifyConfig or modifyDefaultConfig is called


### PR DESCRIPTION
可以通过 `config` 里面的配置来跳过插件，一般是使用 `modifyConfig` 和 `modifyDefaultConfig` 来控制插件的启用情况