### PR TITLE
fix(bundler-vite): set optimize entries for pre-bundling deps

### DIFF
--- a/packages/bundler-vite/src/config/config.ts
+++ b/packages/bundler-vite/src/config/config.ts
@@ -17,6 +17,7 @@ interface IOpts {
 export async function getConfig(opts: IOpts): Promise<ViteInlineConfig> {
   const applyOpts = {
     ...opts.userConfig,
+    entry: opts.entry,
     extraBabelPlugins: [
       ...(opts.extraBabelPlugins || []),
       ...(opts.userConfig.extraBabelPlugins || []),

--- a/packages/bundler-vite/src/config/transformer/optimizeDeps.ts
+++ b/packages/bundler-vite/src/config/transformer/optimizeDeps.ts
@@ -4,7 +4,10 @@ import type { IConfigProcessor } from '.';
  * transform user config to vite optimizeDeps config
  */
 export default (function optimizeDeps(userConfig) {
-  const config: ReturnType<IConfigProcessor> = { optimizeDeps: {} };
+  const config: ReturnType<IConfigProcessor> = {
+    // configure pre-bundling entries
+    optimizeDeps: { entries: Object.values(userConfig.entry) },
+  };
 
   // include alias which within node_modules for optimize dependencies
   if (typeof userConfig.alias === 'object') {


### PR DESCRIPTION
## Description

设置正确的 `optimizeDeps.entries` 以启用 vite 自带的依赖扫描