### PR TITLE
feat(preset-umi): better write tmp file api for vite mode

### DIFF
--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -33,7 +33,7 @@
     "rollup-plugin-copy": "3.4.0",
     "rollup-plugin-polyfill": "3.0.0",
     "rollup-plugin-visualizer": "5.5.2",
-    "vite": "2.6.14"
+    "vite": "2.7.6"
   },
   "devDependencies": {
     "express": "4.17.1"

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -47,7 +47,7 @@
     "@types/multer": "1.4.7",
     "body-parser": "1.19.0",
     "multer": "1.4.3",
-    "vite": "2.6.13"
+    "vite": "2.7.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -74,6 +74,8 @@ export default (api: IApi) => {
       ...memo.alias,
       '@': args.paths.absSrcPath,
       '@@': args.paths.absTmpPath,
+      // like vite, use to pre-bundling dependencies in vite mode
+      '@fs': '/',
     };
     return memo;
   });

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -2,6 +2,7 @@ import { fsExtra, lodash, Mustache } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
+import transformIEAR from './utils/transformIEAR';
 import { IApi } from './types';
 import { isTypeScriptFile } from './utils/isTypeScriptFile';
 
@@ -101,6 +102,12 @@ export default (api: IApi) => {
       ]
         .filter((text) => text !== false)
         .join('\n');
+
+      // transform imports for all javascript-like files
+      if (/\.(t|j)sx?$/.test(absPath)) {
+        content = transformIEAR({ content, path: absPath }, api);
+      }
+
       if (!existsSync(absPath) || readFileSync(absPath, 'utf-8') !== content) {
         writeFileSync(absPath, content, 'utf-8');
       }

--- a/packages/preset-umi/src/utils/transformIEAR.test.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.test.ts
@@ -1,0 +1,86 @@
+import transformIEAR, { IEAR_REG_EXP } from './transformIEAR';
+
+describe('transform path for import/export/await-import/require', () => {
+  it('match cases', () => {
+    const cases = [
+      "import normal from '/normal';",
+      "import Upper from '/uppper';",
+      "import $_Pl from '/mixed-var';",
+      "import * as NS from '/ns';",
+      "import type * as type from '/type';",
+      "import { member1, member2 as b } from '/member';",
+      "import mixed, { member1, member2 as b, type c } from '/mixed';",
+      `import {
+        breakline,
+        type a,
+        member as b
+      }
+      from
+      '/breakline';`,
+      ";import semic from '/semic';",
+      'import double_quotes from "/double_quotes";',
+      "import escape from '/I_am'_escape';",
+      "import '/.umi/a'",
+      "export * from '/export-all';",
+      "export { member } from '/export-member';",
+      "export { default as d, member1, member2 as b } from '/export-mixed';",
+      "await import('/import');",
+      "require('/require');",
+    ];
+
+    expect(cases.join('\n').match(IEAR_REG_EXP)).toHaveLength(cases.length);
+  });
+
+  it('unmatch cases', () => {
+    const cases = [
+      "import pkg from 'pkg';",
+      "import relative from './relative';",
+      "import alias from '@@/alias';",
+      "import http from 'http://www.example.com';",
+      "export * from 'pkg';",
+      "export { member } from './relative';",
+      "export { default as d } from '@@/alias';",
+      "a.import('/member-import');",
+      "require.resolve('/require-resolve');",
+      "{ someKey: '/path/to/some/key' }",
+      "// import comment from '/comment';",
+      `import invalidQuotes from '/invalid";`,
+      "import * as a, { member } from '/error-syntax';",
+    ];
+
+    expect(cases.join('\n').match(IEAR_REG_EXP)).toBeNull();
+  });
+
+  it('some syntax eror cases still be matched (unhandled)', () => {
+    const cases = [
+      "export * as b from '/error-syntax';",
+      "import type a, from '/error-syntax';",
+      "import from '/error-syntax';",
+      "import { a-b45*Y } from '/error-syntax';",
+    ];
+
+    expect(cases.join('\n').match(IEAR_REG_EXP)).toHaveLength(cases.length);
+  });
+
+  it('transform .umi & node_modules', () => {
+    const cases = [
+      "import module from '/path/to/.umi/plugin-tmp';",
+      "import pkg from '/path/to/node_modules/pkg';",
+    ];
+
+    expect(
+      transformIEAR(
+        {
+          content: cases.join('\n'),
+          path: '/path/to/.umi/plugin-self/index.ts',
+        },
+        { paths: { absTmpPath: '/path/to/.umi' } } as any,
+      ),
+    ).toEqual(
+      cases
+        .join('\n')
+        .replace('/path/to/.umi', '..')
+        .replace('/path/to/node_modules', '@fs/path/to/node_modules'),
+    );
+  });
+});

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -1,0 +1,93 @@
+import { winPath } from '@umijs/utils';
+import { dirname, relative } from 'path';
+import type { IApi } from '../types';
+
+/**
+ * import/export/await-import/require match regular expression
+ */
+export const IEAR_REG_EXP = new RegExp(
+  [
+    // match content before quote ($1)
+    '(',
+    [
+      // import/export statements
+      [
+        '(?:',
+        // match head
+        '(?:^|\\r|\\n|;)\\s*',
+        // match identifier
+        '(?:import|export)\\s+',
+        [
+          '(?:',
+          '(?:',
+          // match body
+          [
+            // match default & member import
+            [
+              // match default import
+              [
+                '(?:',
+                // match type import
+                '(?:type\\s*)?',
+                // match variable name
+                '[a-zA-Z_$][\\w_$]*\\s*,?\\s+',
+                // optional
+                ')?',
+              ].join(''),
+              // match member import/export (optional)
+              '(?:{[^}]+}\\s+)?',
+            ].join(''),
+            // match contents import/export
+            '(?:type\\s*)?\\*\\s+(?:as\\s+[a-zA-Z][\\w_$]*\\s+)?',
+          ].join('|'),
+          ')',
+          // match from
+          'from\\s+',
+          // match direct file import
+          '|\\s*',
+          ')',
+        ].join(''),
+        ')',
+      ].join(''),
+      // import/require call
+      [
+        // match head (must be single function name)
+        '(?:^|[^a-zA-Z\\w_$\\.])',
+        // match call
+        '(?:import|require)\\(\\s*',
+      ].join(''),
+    ].join('|'),
+    ')',
+    '(?:',
+    // match quotes ($2)
+    `('|")`,
+    // match absolute file path ($3)
+    `(\\/.*[^\\\\])\\2`,
+    ')',
+  ].join(''),
+  // match full-content
+  'g',
+);
+
+/**
+ * transform absolute import/export/await-import/require path
+ * @note  use to vite can deps:
+ *        transform to relative path for .umi dir imports
+ *        prefix `@fs` for node_modules imports
+ */
+export default function transformIEAR(
+  { content, path }: { content: string; path: string },
+  api: IApi,
+) {
+  return content.replace(IEAR_REG_EXP, (_, prefix, quote, absPath) => {
+    if (absPath.startsWith(api.paths.absTmpPath)) {
+      // transform .umi absolute imports
+      absPath = winPath(relative(dirname(path), absPath));
+    } else if (absPath.includes('node_modules')) {
+      // transform node_modules absolute imports
+      absPath = `@fs${absPath}`;
+    }
+
+    return `${prefix}${quote}${absPath}${quote}`;
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,18 +312,18 @@ importers:
       rollup-plugin-copy: 3.4.0
       rollup-plugin-polyfill: 3.0.0
       rollup-plugin-visualizer: 5.5.2
-      vite: 2.6.14
+      vite: 2.7.6
     dependencies:
       '@svgr/core': 6.0.0
       '@umijs/bundler-utils': link:../bundler-utils
       '@umijs/utils': link:../utils
-      '@vitejs/plugin-legacy': 1.6.3_vite@2.6.14
+      '@vitejs/plugin-legacy': 1.6.3_vite@2.7.6
       '@vitejs/plugin-react': 1.1.0
       postcss-preset-env: 7.0.1
       rollup-plugin-copy: 3.4.0
       rollup-plugin-polyfill: 3.0.0
       rollup-plugin-visualizer: 5.5.2
-      vite: 2.6.14
+      vite: 2.7.6
     devDependencies:
       express: 4.17.1
 
@@ -554,7 +554,7 @@ importers:
       react-dom: 18.0.0-rc.0
       react-router: 6.1.1
       react-router-dom: 6.1.1
-      vite: 2.6.13
+      vite: 2.7.6
     dependencies:
       '@types/multer': 1.4.7
       '@umijs/ast': link:../ast
@@ -578,7 +578,7 @@ importers:
       '@types/body-parser': 1.19.2
       body-parser: 1.19.0
       multer: 1.4.3
-      vite: 2.6.13
+      vite: 2.7.6
 
   packages/renderer-react:
     specifiers:
@@ -4797,7 +4797,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@vitejs/plugin-legacy/1.6.3_vite@2.6.14:
+  /@vitejs/plugin-legacy/1.6.3_vite@2.7.6:
     resolution: {integrity: sha512-YivdG6gT91/wjFL6woTwVRgK9KHrju8GwXwgv5FdfAVo0GK0FK4V+YEobmDKRcOMKXQ1U5awY5HqbPIsoJalKQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -4808,7 +4808,7 @@ packages:
       magic-string: 0.25.7
       regenerator-runtime: 0.13.9
       systemjs: 6.11.0
-      vite: 2.6.14
+      vite: 2.7.6
     dev: false
 
   /@vitejs/plugin-react/1.1.0:
@@ -12519,6 +12519,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.1
 
+  /postcss/8.4.5:
+    resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.1.30
+      picocolors: 1.0.0
+      source-map-js: 1.0.1
+
   /prelude-ls/1.1.2:
     resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
     engines: {node: '>= 0.8.0'}
@@ -15376,8 +15384,8 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite/2.6.13:
-    resolution: {integrity: sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==}
+  /vite/2.7.6:
+    resolution: {integrity: sha512-PBNoc87rDYLtkpFU9dbVeGdbcyKzz6c34oScqivE3FEa3BhVa4ASupCzcz0eDIiSECovfLcQnLUJt9vhiEU08g==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -15393,36 +15401,11 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.13.15
-      postcss: 8.4.4
+      postcss: 8.4.5
       resolve: 1.20.0
       rollup: 2.60.2
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /vite/2.6.14:
-    resolution: {integrity: sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.13.15
-      postcss: 8.4.4
-      resolve: 1.20.0
-      rollup: 2.60.2
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
 
   /vm-browserify/1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}


### PR DESCRIPTION
## Description

优化 `writeTmpFile` api，自动转换 import/export/await-import/require 的绝对路径为相对路径（`.umi` 下的引入）或 `@fs` 前缀（`node_modules` 下的引入），以便支持 vite 扫描正确扫描依赖。

尝试各种方案后，语句识别采用了正则匹配，并通过表达式拆分 + 测试用例尽量保证可维护性，但推测仍有边界 case，未来遇到了再看。

其他方案的问题：
1. `es-module-lexer`，能准确识别 import 语句的位置，但不支持 JSX，识别会报错
2. `esbuild`，支持 JSX，但无法准确识别 import 语句的位置并且做替换，用 replace 很容易误触发