### PR TITLE
fix(preset-umi): head dot lost for relative path in writeTmpFile

### DIFF
--- a/packages/preset-umi/src/utils/transformIEAR.test.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.test.ts
@@ -66,6 +66,7 @@ describe('transform path for import/export/await-import/require', () => {
     const cases = [
       "import module from '/path/to/.umi/plugin-tmp';",
       "import pkg from '/path/to/node_modules/pkg';",
+      "import sibling from '/path/to/.umi/plugin-self/sibling.ts';",
     ];
 
     expect(
@@ -80,6 +81,7 @@ describe('transform path for import/export/await-import/require', () => {
       cases
         .join('\n')
         .replace('/path/to/.umi', '..')
+        .replace('/path/to/.umi/plugin-self', '.')
         .replace('/path/to/node_modules', '@fs/path/to/node_modules'),
     );
   });

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -89,7 +89,11 @@ export default function transformIEAR(
   return content.replace(IEAR_REG_EXP, (_, prefix, quote, absPath) => {
     if (absPath.startsWith(api.paths.absTmpPath)) {
       // transform .umi absolute imports
-      absPath = winPath(relative(dirname(path), absPath));
+      absPath = winPath(relative(dirname(path), absPath)).replace(
+        // prepend ./ for same or sub level imports
+        /^(?!\.\.\/)/,
+        './',
+      );
     } else if (absPath.includes('node_modules')) {
       // transform node_modules absolute imports
       absPath = `@fs${absPath}`;


### PR DESCRIPTION
#### Description

修复 `writeTmpFile` 时 `.umi` 下同级/子级的绝对路径引入缺少头部 `./` 导致 import 失败的 bug