### PR TITLE
fix: mock path

### DIFF
--- a/packages/preset-umi/src/features/mock/fixtures/normal/mock/b.ts
+++ b/packages/preset-umi/src/features/mock/fixtures/normal/mock/b.ts
@@ -1,4 +1,5 @@
 
 export default {
-  '/api/b': { b: 1 },
+  'Get  /api/b': { b: 1 },
+  'Get /api/c': { b: 1 },
 }

--- a/packages/preset-umi/src/features/mock/getMockData.test.ts
+++ b/packages/preset-umi/src/features/mock/getMockData.test.ts
@@ -7,5 +7,5 @@ test('normal', () => {
   const ret = getMockData({
     cwd: join(fixtures, 'normal'),
   });
-  expect(Object.keys(ret)).toEqual(['GET /api/a', 'GET /api/b']);
+  expect(Object.keys(ret)).toEqual(['GET /api/a', 'GET /api/b', 'GET /api/c']);
 });

--- a/packages/preset-umi/src/features/mock/getMockData.ts
+++ b/packages/preset-umi/src/features/mock/getMockData.ts
@@ -57,7 +57,7 @@ function getMock(opts: { key: string; obj: any }): IMock {
 }
 
 function parseKey(key: string) {
-  const spliced = key.split(' ');
+  const spliced = key.split(/\s+/);
   const len = spliced.length;
   if (len === 1) {
     return { method: DEFAULT_METHOD, path: key };
@@ -68,6 +68,8 @@ function parseKey(key: string) {
       VALID_METHODS.includes(upperCaseMethod),
       `method ${method} is not supported`,
     );
+    assert(path, `${key}, path is undefined`);
+
     return { method: upperCaseMethod, path };
   }
 }


### PR DESCRIPTION
```
'GET  /api/login/captcha':  (req: Request, res: Response) => {return res.json('captcha-xxx');},
```

中间的有多个空格的时候，被识别成 `[method, path]` ，path 是空的，就会覆盖掉请求。
`http://localhost:8000/ ===>'captcha-xxx'`