### PR TITLE
feat: complete esmi for bigfish example

### DIFF
--- a/packages/bundler-vite/src/config/transformer/alias.ts
+++ b/packages/bundler-vite/src/config/transformer/alias.ts
@@ -1,0 +1,23 @@
+import type { IConfigProcessor } from '.';
+
+/**
+ * transform umi alias to vite alias
+ */
+export default (function alias(userConfig) {
+  const config: ReturnType<IConfigProcessor> = {};
+
+  if (typeof userConfig.alias === 'object') {
+    config.resolve = {
+      alias: Object.entries<string>(userConfig.alias).map(([name, target]) => ({
+        // supports webpack suffix $ and less-loader prefix ~
+        // example:
+        //   - dep => ^~?dep(?=\/|$)
+        //   - dep$ => ^~?dep$
+        find: new RegExp(`^~?${name.replace(/(?<!\$)$/, '(?=/|$)')}`),
+        replacement: target,
+      })),
+    };
+  }
+
+  return config;
+} as IConfigProcessor);

--- a/packages/bundler-vite/src/config/transformer/css.ts
+++ b/packages/bundler-vite/src/config/transformer/css.ts
@@ -25,13 +25,6 @@ export default (function css(userConfig) {
     css: { postcss: {}, preprocessorOptions: {} },
     resolve: {
       alias: [
-        // to support less-loader ~ for alias deps
-        ...Object.entries<string>(userConfig.alias)
-          .filter(([_, target]) => target.includes('node_modules'))
-          .map(([dep, target]) => ({
-            find: `~${dep}`,
-            replacement: target,
-          })),
         // to support less-loader ~ for local deps, refer: https://github.com/vitejs/vite/issues/2185
         { find: /^~/, replacement: '' },
       ],

--- a/packages/bundler-vite/src/config/transformer/index.ts
+++ b/packages/bundler-vite/src/config/transformer/index.ts
@@ -1,5 +1,6 @@
 import type { InlineConfig as ViteInlineConfig } from 'vite';
 import { mergeConfig } from 'vite';
+import alias from './alias';
 import css from './css';
 import define from './define';
 import devServer from './devServer';
@@ -27,6 +28,7 @@ export default (userConfig: ITmpUserConfig): ViteInlineConfig => {
   const transformers = [
     rename,
     devServer,
+    alias, // must before css for support ~ prefix from less-loader
     css,
     rollup,
     react,

--- a/packages/bundler-vite/src/config/transformer/rename.ts
+++ b/packages/bundler-vite/src/config/transformer/rename.ts
@@ -1,7 +1,6 @@
 import type { IConfigProcessor } from '.';
 
 const MAPPING = {
-  alias: 'resolve.alias',
   extraVitePlugins: 'plugins',
   inlineLimit: 'build.assetsInlineLimit',
   manifest: 'build.manifest',

--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -35,7 +35,13 @@ interface IOpts {
 
 export class Service {
   private opts: IOpts;
-  appData: { deps?: Record<string, string>; [key: string]: any } = {};
+  appData: {
+    deps?: Record<
+      string,
+      { version: string; matches: string[]; subpaths: string[] }
+    >;
+    [key: string]: any;
+  } = {};
   args: yParser.Arguments = { _: [], $0: '' };
   commands: Record<string, Command> = {};
   generators: Record<string, Generator> = {};

--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -17,9 +17,9 @@ export default (api: IApi) => {
 
   const requestTpl = `
 import axios, {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse,
 } from '{{{axiosPath}}}';
 import useUmiRequest, { UseRequestProvider } from '{{{umiRequestPath}}}';
 import { message, notification } from '{{{antdPkg}}}';

--- a/packages/preset-umi/src/features/esmi/esbuildPlugins/requireToImport.ts
+++ b/packages/preset-umi/src/features/esmi/esbuildPlugins/requireToImport.ts
@@ -1,0 +1,68 @@
+import { Plugin, PluginBuild } from '@umijs/bundler-utils/compiled/esbuild';
+import { camelCase } from '@umijs/utils/compiled/lodash';
+import type { DepOptimizationOptions } from 'vite';
+
+/**
+ * transform require call to import
+ */
+export default function requireToImportPlugin({
+  exclude,
+}: {
+  exclude: NonNullable<DepOptimizationOptions['exclude']>;
+}): Plugin {
+  const regSafeExclude = exclude.map((e) =>
+    e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  );
+  const requireRegExp = new RegExp(`^(${regSafeExclude.join('|')})$`);
+
+  return {
+    name: 'preset-umi:esmi-require-to-import',
+
+    setup(build: PluginBuild) {
+      // handler require calls for external deps
+      build.onResolve(
+        {
+          filter: requireRegExp,
+        },
+        async (args) => {
+          if (args.kind === 'require-call') {
+            return {
+              path: args.path,
+              namespace: 'esmi-require-to-import',
+              pluginData: {
+                resolveDir: args.resolveDir,
+              },
+            };
+          }
+        },
+      );
+
+      // replace load content
+      build.onLoad(
+        {
+          filter: /.*/,
+          namespace: 'esmi-require-to-import',
+        },
+        (args) => {
+          const { resolveDir } = args.pluginData || {};
+          const packageName = args.path;
+          const starSpecifier = `${camelCase(packageName)}Star`;
+          const defaultSpecifier = `${camelCase(packageName)}Default`;
+
+          return {
+            resolveDir,
+            contents: [
+              `import * as ${starSpecifier} from '${packageName}';`,
+              '',
+              `const ${defaultSpecifier} = ${starSpecifier}.default ? ${starSpecifier}.default : ${starSpecifier};`,
+              '',
+              `export default ${defaultSpecifier};`,
+              `export * from '${packageName}';`,
+              '',
+            ].join('\n'),
+          };
+        },
+      );
+    },
+  };
+}

--- a/packages/preset-umi/src/features/esmi/esbuildPlugins/topLevelExternal.ts
+++ b/packages/preset-umi/src/features/esmi/esbuildPlugins/topLevelExternal.ts
@@ -1,0 +1,43 @@
+import { Plugin, PluginBuild } from '@umijs/bundler-utils/compiled/esbuild';
+import type { DepOptimizationOptions } from 'vite';
+import type { createResolver } from '../../../libs/scan';
+
+/**
+ * only external top level import, exclude sub-path imports for esmi
+ * example:
+ *   - import from 'antd' will be externalized
+ *   - import from 'antd/dist/antd.less' will not be externalized
+ */
+export default function topLevelExternal({
+  exclude,
+  resolver,
+}: {
+  exclude: NonNullable<DepOptimizationOptions['exclude']>;
+  resolver: ReturnType<typeof createResolver>;
+}): Plugin {
+  const regSafeExclude = exclude.map((e) =>
+    e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  );
+  const subImportRegExp = new RegExp(`^(${regSafeExclude.join('|')})/`);
+  const extRegExp = /\.((?<!d)\.ts|jsx?|tsx)$/;
+
+  return {
+    name: 'preset-umi:esmi-top-level-external',
+
+    setup(build: PluginBuild) {
+      build.onResolve(
+        {
+          filter: subImportRegExp,
+        },
+        async (args) => {
+          const resolved = await resolver.resolve(args.resolveDir, args.path);
+
+          // only process javascript-like files
+          if (extRegExp.test(resolved)) {
+            return { path: resolved };
+          }
+        },
+      );
+    },
+  };
+}

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -1,12 +1,12 @@
 import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import MagicString from 'magic-string';
 import { join } from 'path';
+import type { Plugin, ResolvedConfig } from 'vite';
 import { createResolver, scan } from '../../libs/scan';
-import Service, { IImportmapData, IPkgData } from './Service';
+import type { IApi } from '../../types';
 import requireToImport from './esbuildPlugins/requireToImport';
 import topLevelExternal from './esbuildPlugins/topLevelExternal';
-import type { Plugin, ResolvedConfig } from 'vite';
-import type { IApi } from '../../types';
+import Service, { IImportmapData, IPkgData } from './Service';
 
 let importmap: IImportmapData['importMap'] = { imports: {}, scopes: {} };
 let importmatches: Record<string, string> = {};

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -1,36 +1,60 @@
 import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import MagicString from 'magic-string';
 import { join } from 'path';
-import type { Plugin, ResolvedConfig } from 'vite';
 import { createResolver, scan } from '../../libs/scan';
-import type { IApi } from '../../types';
 import Service, { IImportmapData, IPkgData } from './Service';
+import requireToImport from './esbuildPlugins/requireToImport';
+import topLevelExternal from './esbuildPlugins/topLevelExternal';
+import type { Plugin, ResolvedConfig } from 'vite';
+import type { IApi } from '../../types';
 
 let importmap: IImportmapData['importMap'] = { imports: {}, scopes: {} };
+let importmatches: Record<string, string> = {};
 
 /**
  * esmi vite plugin
  */
-function esmi(opts: { handleHotUpdate?: Plugin['handleHotUpdate'] }): Plugin {
+function esmi(opts: {
+  handleHotUpdate?: Plugin['handleHotUpdate'];
+  resolver: ReturnType<typeof createResolver>;
+}): Plugin {
   return {
     name: 'preset-umi:esmi',
 
     configResolved(config: ResolvedConfig) {
       const { include, exclude } = config.optimizeDeps;
 
+      config.optimizeDeps.include ??= [];
+
       // do not pre-compile deps which will be loaded by importmap (for top-level deps)
       if (include?.length) {
         config.optimizeDeps.include = include!.filter(
-          (item) => !importmap.imports[item],
+          (item) => !importmatches[item] && !importmap.imports[item],
         );
       }
 
-      // exclude pre-compile deps which within importmap by default (for nested deps)
-      config.optimizeDeps.exclude = (exclude || []).concat(
-        Object.keys(importmap.imports).filter((item) =>
-          exclude?.includes(item),
-        ),
-      );
+      // exclude pre-compile deps
+      config.optimizeDeps.exclude = [
+        ...new Set([
+          // deps from user config
+          ...(exclude || []),
+          // deps from local scan
+          ...Object.keys(importmatches),
+          // deps from esmi analyze result
+          ...Object.keys(importmap.imports),
+        ]),
+      ];
+
+      // apply esbuild plugins
+      config.optimizeDeps.esbuildOptions ??= {};
+      config.optimizeDeps.esbuildOptions!.plugins = [
+        // transform require call to import
+        requireToImport({ exclude: config.optimizeDeps.exclude }),
+        topLevelExternal({
+          exclude: config.optimizeDeps.exclude,
+          resolver: opts.resolver,
+        }),
+      ].concat(config.optimizeDeps.esbuildOptions!.plugins || []);
     },
 
     transform(source) {
@@ -44,9 +68,18 @@ function esmi(opts: { handleHotUpdate?: Plugin['handleHotUpdate'] }): Plugin {
           const { n: specifier, s: start, e: end } = item;
 
           // replace npm package to CDN url for matched imports
-          if (specifier && importmap.imports[specifier]) {
-            s ??= new MagicString(source);
-            s.overwrite(start, end, importmap.imports[specifier]);
+          if (specifier) {
+            const replacement =
+              // search from local scan matches first (for alias)
+              (importmatches[specifier] &&
+                importmap.imports[importmatches[specifier]]) ||
+              // search from esmi analyze result
+              importmap.imports[specifier];
+
+            if (replacement) {
+              s ??= new MagicString(source);
+              s.overwrite(start, end, replacement);
+            }
           }
         });
 
@@ -139,6 +172,21 @@ export default (api: IApi) => {
       // TODO: add local cache and restore
       importmap = (await service.getImportmap(data))?.importMap!;
 
+      // update matches map to dep name
+      importmatches = Object.keys(api.appData.deps).reduce<
+        Record<string, string>
+      >((r, dep) => {
+        // filter subpath imports
+        if (!api.appData.deps![dep].subpaths.length) {
+          // map all matches to dep name
+          api.appData.deps![dep].matches.forEach((m) => {
+            r[m] = dep;
+          });
+        }
+
+        return r;
+      }, {});
+
       // because we will replaced package name to CDN url in vite plugin
       // so we must append scope rules for the CDN url like the import specifier
       // example:
@@ -229,6 +277,7 @@ export default (api: IApi) => {
 
             // TODO: refresh page when importmap changed
           },
+          resolver,
         }),
       );
 

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -50,6 +50,7 @@ function esmi(opts: {
       config.optimizeDeps.esbuildOptions!.plugins = [
         // transform require call to import
         requireToImport({ exclude: config.optimizeDeps.exclude }),
+        // make sure vite only external top-level npm imports, and resolve sub-path npm imports
         topLevelExternal({
           exclude: config.optimizeDeps.exclude,
           resolver: opts.resolver,
@@ -169,7 +170,6 @@ export default (api: IApi) => {
 
     // update importmap from esm if there has new import
     if (hasNewDep) {
-      // TODO: add local cache and restore
       importmap = (await service.getImportmap(data))?.importMap!;
 
       // update matches map to dep name

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -1,7 +1,7 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
 import type { Service } from '@umijs/core';
-import { pkgUp, winPath } from '@umijs/utils';
+import { pkgUp } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
@@ -88,9 +88,7 @@ export async function scan(opts: {
     cache.set(depPath!, deps);
 
     for (const dep of deps) {
-      const resolved = winPath(
-        await opts.resolver.resolve(dirname(depPath!), dep.url),
-      );
+      const resolved = await opts.resolver.resolve(dirname(depPath!), dep.url);
       if (
         resolved.includes('node_modules') ||
         resolved.includes('umi-next/packages')

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -1,11 +1,11 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
+import type { Service } from '@umijs/core';
 import { pkgUp, winPath } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
 import { dirname, extname } from 'path';
-import type { Service } from '@umijs/core';
 
 enum ImportType {
   import = 'import',
@@ -122,8 +122,9 @@ export async function scan(opts: {
                     // match no ext name path
                     resolved.replace(/\/\.[^\.]+$/, ''),
                     // match parent dir for index module
-                    // cannot to it, will cause exclude rule broken
-                    // ...(/\/index[^\/]+$/.test(resolved) ? [dirname(resolved)] : []),
+                    ...(/\/index[^\/]+$/.test(resolved)
+                      ? [dirname(resolved)]
+                      : []),
                   ]
                 : []),
             ]),

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -1,10 +1,11 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
-import { pkgUp } from '@umijs/utils';
+import { pkgUp, winPath } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
 import { dirname, extname } from 'path';
+import type { Service } from '@umijs/core';
 
 enum ImportType {
   import = 'import',
@@ -73,10 +74,11 @@ export async function scan(opts: {
   entry: string;
   externals: any;
   resolver: any;
-}): Promise<Record<string, string>> {
+}) {
   const cache = new Map<string, any>();
   const queueDeps: string[] = [opts.entry];
-  const ret: Record<string, string> = {};
+  const ret: Service['appData']['deps'] = {};
+
   while (queueDeps.length) {
     const depPath = queueDeps.shift();
     if (cache.has(depPath!)) continue;
@@ -86,7 +88,9 @@ export async function scan(opts: {
     cache.set(depPath!, deps);
 
     for (const dep of deps) {
-      const resolved = await opts.resolver.resolve(dirname(depPath!), dep.url);
+      const resolved = winPath(
+        await opts.resolver.resolve(dirname(depPath!), dep.url),
+      );
       if (
         resolved.includes('node_modules') ||
         resolved.includes('umi-next/packages')
@@ -94,7 +98,45 @@ export async function scan(opts: {
         const pkgPath = pkgUp.sync({ cwd: resolved });
         assert(pkgPath, `package.json for found for ${resolved}`);
         const pkg = require(pkgPath);
-        ret[pkg.name] = pkg.version;
+        const entryResolved = await opts.resolver
+          .resolve(dirname(pkgPath), pkg.name)
+          // alias may resolve error (eg: dva from @umijs/plugins)
+          // fallback to null for mark it as subpath usage
+          .catch(() => null);
+        const isSubpath = entryResolved !== resolved;
+
+        ret[pkg.name] = {
+          version: pkg.version,
+          // collect entry matches
+          matches: [
+            // avoid duplicate
+            ...new Set([
+              ...(ret[pkg.name]?.matches || []),
+              // only collect non-subpath matches
+              ...(!isSubpath
+                ? [
+                    // match origin path from source code
+                    dep.url,
+                    // match resolved absolute path
+                    resolved,
+                    // match no ext name path
+                    resolved.replace(/\/\.[^\.]+$/, ''),
+                    // match parent dir for index module
+                    // cannot to it, will cause exclude rule broken
+                    // ...(/\/index[^\/]+$/.test(resolved) ? [dirname(resolved)] : []),
+                  ]
+                : []),
+            ]),
+          ],
+          // collect subpath matches
+          subpaths: [
+            // avoid duplicate
+            ...new Set([
+              ...(ret[pkg.name]?.subpaths || []),
+              ...(isSubpath ? [dep.url] : []),
+            ]),
+          ],
+        };
       } else if (
         ['.ts', '.tsx', '.js', '.jsx', '.mjs'].includes(extname(resolved))
       ) {

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -2,9 +2,9 @@ import { fsExtra, lodash, Mustache } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
-import transformIEAR from './utils/transformIEAR';
 import { IApi } from './types';
 import { isTypeScriptFile } from './utils/isTypeScriptFile';
+import transformIEAR from './utils/transformIEAR';
 
 export default (api: IApi) => {
   [


### PR DESCRIPTION
## Description

完善 esmi 及相关功能以支持 Bigfish 示例项目，主要改动点如下：
1. scan 阶段采集 import paths，并且区分 entry match 和 sub-path match
2. 根据 scan 的结果，不对 entry match 做预编译（例如绝对路径引入 entry 和包名引入是等价的）
3. 根据 scan 的结果，额外挂载 esbuild 插件实现不对 sub-path match 做 external，以便走本地编译
3. 额外挂载 esbuild 插件，将已被 external、又被 require 引入的依赖转换为 import 引入，确保可以在浏览器环境和 `importmap` 一起 work

与项目跑通有关的附带改动点：
1. bundler-vite 的 alias 配置转换支持 webpack 的 `$` 修饰符，并且将 less-loader 的 `~` 一并用正则匹配处理了
2. plugin-request 的临时 `request.ts` 中对 axois 类型的引入加上 type 标识符，否则会导致在浏览器环境支持的时候从 CDN 产物中找不到导出

TODO：
1. 临时文件用 `@fs` 访问绝对路径会丢失类型，初步确定 tsconfig.json 里加个 paths
2. antd 的样式目前不走云构建，本地得做白名单引入