### PR TITLE
feat: mock ignore d.ts

### DIFF
--- a/packages/preset-umi/src/features/mock/getMockData.test.ts
+++ b/packages/preset-umi/src/features/mock/getMockData.test.ts
@@ -6,6 +6,7 @@ const fixtures = join(__dirname, './fixtures');
 test('normal', () => {
   const ret = getMockData({
     cwd: join(fixtures, 'normal'),
+    mockConfig: {},
   });
   expect(Object.keys(ret)).toEqual(['GET /api/a', 'GET /api/b', 'GET /api/c']);
 });


### PR DESCRIPTION
1、mock 文件忽略 `d.ts`
2、当 mock 文件夹下的文件没有导出 `default` 时应该被忽略，而不是报错终止
3、当 mock 重复定义时，给出日志提示，按先后加载的顺序覆盖，而不是报错终止。
存在一个定义被多个页面使用的情况，根据 block 的拆包，集成之后会有重复的定义项 