### PR TITLE
feat: layout plugin runtime support initialState

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -73,7 +73,9 @@ export default () => {
   const runtimeConfig = pluginManager.applyPlugins({
     key: 'layout',
     type: 'modify',
-    initialValue: {},
+    initialValue: {
+      ...initialInfo
+    },
   });
   return (
     <ProLayout


### PR DESCRIPTION
可以在 layout 的 runtime 配置中使用 initialState 变量
```
export const layout = ({
  initialState,
  setInitialState,
}) => {
  return {}
}
```