### PR TITLE
fix: deps scan in vite mode

### DIFF
--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -1,7 +1,7 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
 import { winPath } from '@umijs/utils';
-import { extname } from 'path';
+import { dirname, extname } from 'path';
 
 export async function parseModule(opts: { content: string; path: string }) {
   let content = opts.content;
@@ -18,7 +18,9 @@ export async function parseModule(opts: { content: string; path: string }) {
 }
 
 export function isDepPath(path: string) {
-  const umiMonorepoPath = winPath(__dirname).match(/([^/]\/packages)\//)?.[1];
+  const umiMonorepoPath = winPath(dirname(dirname(__dirname))).match(
+    /([^/]+\/packages)$/,
+  )?.[1];
 
   return (
     path.includes('node_modules') ||

--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -1,7 +1,6 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
-import { winPath } from '@umijs/utils';
-import { dirname, extname } from 'path';
+import { extname } from 'path';
 
 export async function parseModule(opts: { content: string; path: string }) {
   let content = opts.content;
@@ -18,12 +17,10 @@ export async function parseModule(opts: { content: string; path: string }) {
 }
 
 export function isDepPath(path: string) {
-  const umiMonorepoPath = winPath(dirname(dirname(__dirname))).match(
-    /([^/]+\/packages)$/,
-  )?.[1];
+  const umiMonorepoPaths = ['umi/packages/', 'umi-next/packages/'];
 
   return (
     path.includes('node_modules') ||
-    (umiMonorepoPath && path.includes(umiMonorepoPath))
+    umiMonorepoPaths.some((p) => path.includes(p))
   );
 }

--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -1,5 +1,6 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
+import { winPath } from '@umijs/utils';
 import { extname } from 'path';
 
 export async function parseModule(opts: { content: string; path: string }) {
@@ -14,4 +15,13 @@ export async function parseModule(opts: { content: string; path: string }) {
 
   await init;
   return parse(content);
+}
+
+export function isDepPath(path: string) {
+  const umiMonorepoPath = winPath(__dirname).match(/([^/]\/packages)\//)?.[1];
+
+  return (
+    path.includes('node_modules') ||
+    (umiMonorepoPath && path.includes(umiMonorepoPath))
+  );
 }

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -63,7 +63,7 @@ export default (api: IApi) => {
   // babel-plugin-import
   api.addExtraBabelPlugins(() => {
     const style = api.config.antd.style || 'less';
-    return api.config.antd.import
+    return api.config.antd.import && !api.args.vite
       ? [
           [
             require.resolve('babel-plugin-import'),
@@ -117,7 +117,7 @@ export function rootContainer(container) {
   // import antd style if antd.import is not configured
   api.addEntryImportsAhead(() => {
     const style = api.config.antd.style || 'less';
-    return api.config.antd.import
+    return api.config.antd.import && !api.args.vite
       ? []
       : [
           {

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -63,7 +63,7 @@ export default (api: IApi) => {
   // babel-plugin-import
   api.addExtraBabelPlugins(() => {
     const style = api.config.antd.style || 'less';
-    return api.config.antd.import && !api.args.vite
+    return api.config.antd.import && !api.appData.vite
       ? [
           [
             require.resolve('babel-plugin-import'),
@@ -117,7 +117,7 @@ export function rootContainer(container) {
   // import antd style if antd.import is not configured
   api.addEntryImportsAhead(() => {
     const style = api.config.antd.style || 'less';
-    return api.config.antd.import && !api.args.vite
+    return api.config.antd.import && !api.appData.vite
       ? []
       : [
           {

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -51,9 +51,6 @@ export default (api: IApi) => {
         resolver,
       });
 
-      // skip umi by default
-      delete api.appData.deps['umi'];
-
       // FIXME: force include react & react-dom
       api.appData.deps['react'].version = api.appData.react.version;
       api.appData.deps['react-dom'] = {

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -35,6 +35,7 @@ export default (api: IApi) => {
     stage: Number.NEGATIVE_INFINITY,
   });
 
+  // used in esmi and vite
   api.register({
     key: 'updateAppDataDeps',
     async fn() {

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -21,6 +21,8 @@ export default (api: IApi) => {
       version: require(join(api.config.alias.react, 'package.json')).version,
     };
     memo.appJS = await getAppJsInfo();
+    memo.vite = api.args.vite ? {} : undefined;
+
     return memo;
   });
 

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -149,6 +149,9 @@ export default (api: IApi) => {
       type: api.ApplyPluginsType.event,
     });
 
+    // skip umi by default
+    delete api.appData.deps!['umi'];
+
     const data = generatePkgData(api);
     const deps = data.pkgInfo.exports.reduce(
       (r, exp) => r.concat(exp.deps.map((dep) => dep.name)),

--- a/packages/preset-umi/src/features/esmi/esmi.ts
+++ b/packages/preset-umi/src/features/esmi/esmi.ts
@@ -2,7 +2,7 @@ import { parse as parseImports } from '@umijs/bundler-utils/compiled/es-module-l
 import MagicString from 'magic-string';
 import { join } from 'path';
 import type { Plugin, ResolvedConfig } from 'vite';
-import { createResolver, scan } from '../../libs/scan';
+import { createResolver } from '../../libs/scan';
 import type { IApi } from '../../types';
 import requireToImport from './esbuildPlugins/requireToImport';
 import topLevelExternal from './esbuildPlugins/topLevelExternal';
@@ -144,22 +144,10 @@ export default (api: IApi) => {
   async function refreshImportMap() {
     // scan and module graph
     // TODO: module graph
-    api.appData.deps = await scan({
-      entry: join(api.paths.absTmpPath, 'umi.ts'),
-      externals: api.config.externals,
-      resolver,
+    await api.applyPlugins({
+      key: 'updateAppDataDeps',
+      type: api.ApplyPluginsType.event,
     });
-
-    // skip umi by default
-    delete api.appData.deps['umi'];
-
-    // FIXME: force include react & react-dom
-    api.appData.deps['react'].version = api.appData.react.version;
-    api.appData.deps['react-dom'] = {
-      version: api.appData.react.version,
-      matches: ['react-dom'],
-      subpaths: [],
-    };
 
     const data = generatePkgData(api);
     const deps = data.pkgInfo.exports.reduce(
@@ -173,7 +161,7 @@ export default (api: IApi) => {
       importmap = (await service.getImportmap(data))?.importMap!;
 
       // update matches map to dep name
-      importmatches = Object.keys(api.appData.deps).reduce<
+      importmatches = Object.keys(api.appData.deps!).reduce<
         Record<string, string>
       >((r, dep) => {
         // filter subpath imports

--- a/packages/preset-umi/src/features/vite/vite.ts
+++ b/packages/preset-umi/src/features/vite/vite.ts
@@ -1,0 +1,32 @@
+import type { IApi } from '../../types';
+
+export default (api: IApi) => {
+  // scan deps into api.appData by default for vite mode
+  api.register({
+    key: 'onBeforeCompiler',
+    stage: Number.POSITIVE_INFINITY,
+    async fn() {
+      await api.applyPlugins({
+        key: 'updateAppDataDeps',
+        type: api.ApplyPluginsType.event,
+      });
+    },
+  });
+
+  // include extra monorepo package deps for vite pre-bundle
+  api.modifyViteConfig((memo) => {
+    memo.optimizeDeps = {
+      ...(memo.optimizeDeps || {}),
+      include: memo.optimizeDeps?.include?.concat(
+        Object.values(api.appData.deps!)
+          .map(({ matches }) => matches[0])
+          .filter(
+            (item) =>
+              item?.startsWith('@fs') && !item?.includes('node_modules'),
+          ),
+      ),
+    };
+
+    return memo;
+  });
+};

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -17,6 +17,7 @@ export default () => {
       require.resolve('./features/tmpFiles/tmpFiles'),
       require.resolve('./features/transform/transform'),
       require.resolve('./features/lowImport/lowImport'),
+      require.resolve('./features/vite/vite'),
 
       // commands
       require.resolve('./commands/build'),

--- a/packages/preset-umi/src/libs/scan.test.ts
+++ b/packages/preset-umi/src/libs/scan.test.ts
@@ -13,3 +13,29 @@ test('normal', async () => {
     ],
   });
 });
+
+test('type', async () => {
+  expect(
+    await scanContent({
+      content: [
+        "import type foo1 from 'bar1';",
+        "import type { foo2 } from 'bar2';",
+        "import { foo3, type foo4 } from 'bar34';",
+        "import foo56, { type foo5, type foo6 } from 'bar56';",
+        "export type { foo7 } from 'bar7';",
+        "export { foo8, type foo9 } from 'bar89';",
+        "export { type foo10, type foo11 } from 'bar1011';",
+        "export * from 'bar12';",
+        "export * as b from 'bar13';",
+      ].join(''),
+    }),
+  ).toEqual({
+    deps: [
+      { importType: 'import', url: 'bar34' },
+      { importType: 'import', url: 'bar56' },
+      { importType: 'export', url: 'bar89' },
+      { importType: 'export', url: 'bar12' },
+      { importType: 'export', url: 'bar13' },
+    ],
+  });
+});

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -37,7 +37,7 @@ export async function scanContent(opts: {
         return (
           // skip dynamicImport
           imp.d > -1 ||
-          // import a from or import a
+          // import a from or import a,
           /^import\s+[a-zA-Z_$][\w_$]*(\s+from|\s*,)/.test(stmt) ||
           // export a from or export *
           /^export\s+([a-zA-Z_$][\w_$]*\s+from|\*)/.test(stmt) ||

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -1,5 +1,6 @@
 import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
+import { isDepPath } from '@umijs/bundler-utils';
 import type { Service } from '@umijs/core';
 import { pkgUp } from '@umijs/utils';
 import assert from 'assert';
@@ -89,10 +90,7 @@ export async function scan(opts: {
 
     for (const dep of deps) {
       const resolved = await opts.resolver.resolve(dirname(depPath!), dep.url);
-      if (
-        resolved.includes('node_modules') ||
-        resolved.includes('umi-next/packages')
-      ) {
+      if (isDepPath(resolved)) {
         const pkgPath = pkgUp.sync({ cwd: resolved });
         assert(pkgPath, `package.json for found for ${resolved}`);
         const pkg = require(pkgPath);

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -97,7 +97,7 @@ export async function scan(opts: {
         assert(pkgPath, `package.json for found for ${resolved}`);
         const pkg = require(pkgPath);
         const entryResolved = await opts.resolver
-          .resolve(dirname(pkgPath), pkg.name)
+          .resolve(dirname(pkgPath), '.')
           // alias may resolve error (eg: dva from @umijs/plugins)
           // fallback to null for mark it as subpath usage
           .catch(() => null);

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -1,3 +1,4 @@
+import { isDepPath } from '@umijs/bundler-utils';
 import { winPath } from '@umijs/utils';
 import { dirname, relative } from 'path';
 import type { IApi } from '../types';
@@ -94,7 +95,7 @@ export default function transformIEAR(
         /^(?!\.\.\/)/,
         './',
       );
-    } else if (absPath.includes('node_modules')) {
+    } else if (isDepPath(absPath)) {
       // transform node_modules absolute imports
       // why @fs
       // 由于我们临时文件下大量绝对路径的引用，而绝对路径的引用不会被 Vite 预编译


### PR DESCRIPTION
## Description

修复 vite 及 ESMi 模式不兼容部分插件逻辑导致无法启动的问题，改动点：

1. 修复本地依赖扫描时部分依赖丢失的问题
2. 添加统一的 `isDepPath` 工具函数到 `bundler-utils`，判断是否是三方依赖和 monorepo 子包依赖
3. Vite 模式下强制禁用 `plugin-antd` 的 `babel-plugin-import`
4. 本地依赖扫描时排除 import type，避免 resolve 失败
5. 依赖扫描从『仅 ESMi 启用』变成『Vite 模式均启用』，解决 monorepo 子包依赖无法走 Vite 预编译的问题