### PR TITLE
fix: layout title

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -100,7 +100,7 @@ const { formatMessage } = useIntl();
     <ProLayout
       route={route}
       location={location}
-      title={userConfig.name || 'plugin-layout'}
+      title={userConfig.title || userConfig.name || 'plugin-layout'}
       navTheme="dark"
       siderWidth={256}
       onMenuHeaderClick={(e) => {

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -100,7 +100,7 @@ const { formatMessage } = useIntl();
     <ProLayout
       route={route}
       location={location}
-      title={userConfig.title || userConfig.name || 'plugin-layout'}
+      title={userConfig.title || 'plugin-layout'}
       navTheme="dark"
       siderWidth={256}
       onMenuHeaderClick={(e) => {


### PR DESCRIPTION
修复 layout title 取值问题，项目中一般是
```
{
   title: 'Ant Design Pro',
}
```