### PR TITLE
feat: exports support types

### DIFF
--- a/examples/bigfish/.umirc.ts
+++ b/examples/bigfish/.umirc.ts
@@ -39,7 +39,9 @@ export default defineConfig({
   },
   initialState: {},
   access: {},
-  dva: {},
+  dva: {
+    enableModelsReExport: true,
+  },
   model: {},
   analytics: {
     baidu: 'test',

--- a/examples/bigfish/models/count.ts
+++ b/examples/bigfish/models/count.ts
@@ -1,4 +1,7 @@
-export default {
+import { DvaModel } from 'umi';
+
+export type CountModelState = number;
+const CountModel: DvaModel<CountModelState> = {
   namespace: 'count',
   state: 0,
   reducers: {
@@ -12,3 +15,4 @@ export default {
     },
   },
 };
+export default CountModel;

--- a/examples/bigfish/pages/dva.tsx
+++ b/examples/bigfish/pages/dva.tsx
@@ -1,20 +1,22 @@
 // @ts-ignore
-import { connect } from '@@/plugin-dva';
-// @ts-ignore
 import dayjs from 'moment';
-import React from 'react';
+import React, { FC } from 'react';
+import { connect, ConnectProps, CountModelState } from 'umi';
 
-function mapStateToProps(state: any) {
+function mapStateToProps(state: { count: CountModelState }) {
   return { count: state.count };
 }
-
-export default connect(mapStateToProps)(function HomePage(props: any) {
+interface HomePageProps extends ConnectProps {
+  count: CountModelState;
+}
+const HomePage: FC<HomePageProps> = ({ count, dispatch }) => {
   return (
     <div>
       <h2>dva</h2>
       <p>dayjs: {dayjs().format()}</p>
-      <p>count: {props.count}</p>
-      <button onClick={() => props.dispatch({ type: 'count/add' })}>+</button>
+      <p>count: {count}</p>
+      <button onClick={() => dispatch?.({ type: 'count/add' })}>+</button>
     </div>
   );
-});
+};
+export default connect(mapStateToProps)(HomePage);

--- a/examples/bigfish/tsconfig.json
+++ b/examples/bigfish/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "dist",
+    "sourceMap": true,
+    "jsx": "react",
+    "declaration": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2017",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"],
+    "allowSyntheticDefaultImports": true,
+    "rootDirs": ["/src", "/test", "/mock", "./typings"],
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "allowJs": true,
+    "strict": true,
+    "paths": {
+      "@/*": ["./*"],
+      "@@/*": [".umi/*"]
+    }
+  }
+}

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -225,6 +225,17 @@ export default function EmptyRoute() {
           );
         }
       }
+      // plugins types.ts
+      exports.push('// plugins types.ts');
+
+      for (const plugin of plugins) {
+        let file: string;
+        if (!existsSync(join(api.paths.absTmpPath, plugin, 'types.d.ts'))) {
+          continue;
+        }
+        file = join(api.paths.absTmpPath, plugin, 'types.d');
+        exports.push(`export * from '${file}';`);
+      }
       api.writeTmpFile({
         noPluginDir: true,
         path: 'exports.ts',


### PR DESCRIPTION
如果插件缓存目录下有生成 `types.d.ts`，比如 `.umi/plugin-dva/types.d.ts`
会被 exports.ts 导出 `export * from './plugin-dva/types.d'`
dva 插件增加一个配置 `enableModelsReExport` 启用它，会默认导出 model 文件名规则的类型 
比如 model 文件为 home.ts 会导出 HomeModelState
编写 model
```ts
import type { DvaModel } from 'umi';

// 如果开启 enableModelsReExport ，文件中必须导出 IndexModelState
export interface IndexModelState {
  name: string;
}

const IndexModel: DvaModel<IndexModelState> = {
  namespace: 'index',

  state: {
    name: 'Hello Umi',
  },

  effects: {
    *query({ payload }, { call, put }) {
      yield put({
        type: 'save',
        payload: { name: 'Hello Dva' },
      });
    },
  },
  reducers: {
    save(state, action) {
      return {
        ...state,
        ...action.payload,
      };
    },
  },
};

export default IndexModel;
```
编写页面
```tsx
import {
  connect,
  ConnectProps,
  IndexModelState,
} from 'alita';
import { Button } from 'antd-mobile';
import React from 'react';
import './global.less';
import styles from './index.less';

interface HomePageProps extends ConnectProps {
  index: IndexModelState;
}

const HomePage: React.FC<HomePageProps> = ({ index, dispatch }) => {
  const { name } = index;

  return (
    <div className={styles.title}>
      <h2>dva index model name:{name}</h2>
      <Button
        type="button"
        color="primary"
        fill="solid"
        block
        size="large"
        onClick={() => {
          dispatch!({
            type: 'index/query',
            payload: { },
          });
        }}
      >
        点我修改 dva name
      </Button>
    </div>
  );
};

export default connect(({ index }: { index: IndexModelState }) => ({ index }))(HomePage);

```
