### PR TITLE
docs: provide readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,13 @@ Loving Umi and want to get involved? Thanks!
 # Clone this repo
 $ git clone git@github.com:umijs/umi-next.git
 $ cd umi-next
+
 # Install Dependencies
 $ pnpm i
+
 # Compile Src
 $ pnpm build
+
 # Start dev server for boilerplate example
 $ cd examples/boilerplate
 $ pnpm dev
@@ -34,7 +37,9 @@ $ npm run release
 ```bash
 $ cd examples/boilerplate
 # Must start with pnpm
+
 $ pnpm dev
 # Switch to the vite mode
+
 $ pnpm dev -- --vite
 ```


### PR DESCRIPTION
在CONTRIBUTING.md这个文件的注释与命令之间添加空格，提供可读性，例如：
```bash
# 这是注释
$ a command

# 这是另一行注释
$ another command
```
