### PR TITLE
docs: provide readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,13 @@ Loving Umi and want to get involved? Thanks!
 # Clone this repo
 $ git clone git@github.com:umijs/umi-next.git
 $ cd umi-next
+
 # Install Dependencies
 $ pnpm i
+
 # Compile Src
 $ pnpm build
+
 # Start dev server for boilerplate example
 $ cd examples/boilerplate
 $ pnpm dev
@@ -33,8 +36,10 @@ $ npm run release
 
 ```bash
 $ cd examples/boilerplate
+
 # Must start with pnpm
 $ pnpm dev
+
 # Switch to the vite mode
 $ pnpm dev -- --vite
 ```


### PR DESCRIPTION
修正了格式错误，例如：
```bash
# Must start with pnpm
$ pnpm dev

# Switch to the vite mode
$ pnpm dev -- --vite
```