### PR TITLE
feat(mfsu): mfsu without umi usage

### DIFF
--- a/examples/mfsu-independent/.gitignore
+++ b/examples/mfsu-independent/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/.mfsu
+/dist
+

--- a/examples/mfsu-independent/README.md
+++ b/examples/mfsu-independent/README.md
@@ -1,0 +1,30 @@
+# mfsu-independent
+
+Start the antd + framer-motion project without cache in one second.
+
+![](https://img.alicdn.com/imgextra/i2/O1CN01k8Gjoo1P5rgMGHuuC_!!6000000001790-2-tps-1204-378.png)
+
+## Setup
+
+Install dependency with pnpm or yarn or npm,
+
+```bash
+$ pnpm install
+```
+
+Start dev server,
+
+```bash
+$ pnpm dev
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:8080/
+<i> [webpack-dev-server] On Your Network (IPv4): http://30.230.88.77:8080/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[fe80::1]:8080/
+webpack 5.64.4 compiled successfully in 638 ms
+webpack 5.64.4 compiled successfully in 59 ms
+event - [mfsu] compiled with esbuild successfully in 293 ms
+```
+
+## LICENSE
+
+MIT

--- a/examples/mfsu-independent/index.html
+++ b/examples/mfsu-independent/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Webpack + MFSU</title>
+</head>
+<body>
+
+<div id="root"></div>
+
+</body>
+</html>

--- a/examples/mfsu-independent/package.json
+++ b/examples/mfsu-independent/package.json
@@ -1,0 +1,24 @@
+{
+  "scripts": {
+    "build": "webpack",
+    "dev": "webpack-dev-server"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.16.0",
+    "@babel/preset-env": "^7.16.4",
+    "@babel/preset-react": "^7.16.0",
+    "@babel/preset-typescript": "^7.16.0",
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
+    "@umijs/mfsu": "4.0.0-beta.16",
+    "antd": "^4.17.2",
+    "babel-loader": "^8.2.3",
+    "framer-motion": "^5.3.3",
+    "html-webpack-plugin": "^5.5.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.6.0"
+  }
+}

--- a/examples/mfsu-independent/src/App.tsx
+++ b/examples/mfsu-independent/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Antd from './antd';
+import FramerMotion from './framer-motion';
+
+export default function App() {
+  return (
+    <div>
+      <Antd />
+      <FramerMotion />
+    </div>
+  );
+}

--- a/examples/mfsu-independent/src/antd.tsx
+++ b/examples/mfsu-independent/src/antd.tsx
@@ -1,0 +1,16 @@
+import 'antd/dist/antd.css';
+import Button from 'antd/es/button';
+import DatePicker from 'antd/es/date-picker';
+import Input from 'antd/es/input';
+import React from 'react';
+
+export default () => {
+  return (
+    <div>
+      <h1>Ant Design</h1>
+      <Button type="primary">Button</Button>
+      <Input />
+      <DatePicker />
+    </div>
+  );
+};

--- a/examples/mfsu-independent/src/framer-motion.tsx
+++ b/examples/mfsu-independent/src/framer-motion.tsx
@@ -1,0 +1,34 @@
+import { motion, Reorder } from 'framer-motion';
+import React from 'react';
+
+export default function HomePage() {
+  const [isVisible, setIsVisible] = React.useState(true);
+  const [items, setItems] = React.useState([0, 1, 2, 3]);
+  return (
+    <div>
+      <h1>Framer Motion</h1>
+      <h2>Toggle Visible</h2>
+      <div>
+        <button
+          onClick={() => {
+            setIsVisible((isVisible) => !isVisible);
+          }}
+        >
+          toggle
+        </button>
+      </div>
+      <br />
+      <motion.div animate={{ opacity: isVisible ? 1 : 0 }}>
+        TOGGLE ME
+      </motion.div>
+      <h2>Reorder</h2>
+      <Reorder.Group axis="y" values={items} onReorder={setItems}>
+        {items.map((item) => (
+          <Reorder.Item key={item} value={item}>
+            {item}
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+    </div>
+  );
+}

--- a/examples/mfsu-independent/src/index.tsx
+++ b/examples/mfsu-independent/src/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/mfsu-independent/tsconfig.json
+++ b/examples/mfsu-independent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "target": "es2015",
+    "jsx": "react"
+  },
+  "exclude": ["**/node_modules"]
+}

--- a/examples/mfsu-independent/webpack.config.js
+++ b/examples/mfsu-independent/webpack.config.js
@@ -59,9 +59,6 @@ const config = {
     modules: false,
     entrypoints: false,
   },
-  experiments: {
-    topLevelAwait: true,
-  }
 };
 
 // [mfsu] 4. inject mfsu webpack config

--- a/examples/mfsu-independent/webpack.config.js
+++ b/examples/mfsu-independent/webpack.config.js
@@ -1,0 +1,75 @@
+const path = require('path')
+const webpack = require('webpack');
+const { MFSU } = require('@umijs/mfsu');
+
+// [mfsu] 1. init instance
+const mfsu = new MFSU({
+  implementor: webpack,
+  buildDepWithESBuild: true,
+});
+
+const config = {
+  entry: path.join(__dirname, './src'),
+  mode: 'development',
+  output: {
+    path: path.join(__dirname, './dist'),
+    filename: 'bundle.js',
+    publicPath: '/'
+  },
+  devServer: {
+    // [mfsu] 2. add mfsu middleware
+    setupMiddlewares(middlewares, devServer) {
+      middlewares.unshift(
+        ...mfsu.getMiddlewares()
+      )
+      return middlewares
+    },
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.[jt]sx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
+            plugins: [
+              // [mfsu] 3. add mfsu babel plugins
+              ...mfsu.getBabelPlugins()
+            ]
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new (require('html-webpack-plugin'))({
+      template: path.resolve(__dirname, './index.html')
+    })
+  ],
+  stats: {
+    assets: false,
+    moduleAssets: false,
+    runtime: false,
+    runtimeModules: false,
+    modules: false,
+    entrypoints: false,
+  },
+  experiments: {
+    topLevelAwait: true,
+  }
+};
+
+// [mfsu] 4. inject mfsu webpack config
+const getConfig = async () => {
+  await mfsu.setWebpackConfig({
+    config,
+  });
+  return config
+}
+
+module.exports = getConfig();

--- a/packages/bundler-esbuild/src/cli.ts
+++ b/packages/bundler-esbuild/src/cli.ts
@@ -1,5 +1,5 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
-import { chalk, register, yParser } from '@umijs/utils';
+import { chalk, register, tryPaths, yParser } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync } from 'fs';
 import { basename, extname, join } from 'path';
@@ -49,12 +49,6 @@ if (command === 'build') {
 
 function error(msg: string) {
   console.error(chalk.red(msg));
-}
-
-function tryPaths(paths: string[]) {
-  for (const path of paths) {
-    if (existsSync(path)) return path;
-  }
 }
 
 function getEntryKey(path: string) {

--- a/packages/bundler-vite/src/cli.ts
+++ b/packages/bundler-vite/src/cli.ts
@@ -1,5 +1,5 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
-import { chalk, register, yParser } from '@umijs/utils';
+import { chalk, register, tryPaths, yParser } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync } from 'fs';
 import { basename, extname, join } from 'path';
@@ -66,12 +66,6 @@ if (command === 'build') {
 
 function error(msg: string) {
   console.error(chalk.red(msg));
-}
-
-function tryPaths(paths: string[]) {
-  for (const path of paths) {
-    if (existsSync(path)) return path;
-  }
 }
 
 function getEntryKey(path: string) {

--- a/packages/bundler-webpack/src/cli.ts
+++ b/packages/bundler-webpack/src/cli.ts
@@ -1,5 +1,5 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
-import { chalk, register, yParser } from '@umijs/utils';
+import { chalk, register, tryPaths, yParser } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync } from 'fs';
 import { basename, extname, join } from 'path';
@@ -71,12 +71,6 @@ if (command === 'build') {
 
 function error(msg: string) {
   console.error(chalk.red(msg));
-}
-
-function tryPaths(paths: string[]) {
-  for (const path of paths) {
-    if (existsSync(path)) return path;
-  }
 }
 
 function getEntryKey(path: string) {

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -1,7 +1,8 @@
 import { parseModule } from '@umijs/bundler-utils';
-import { lodash, logger } from '@umijs/utils';
+import { lodash, logger, tryPaths } from '@umijs/utils';
+import assert from 'assert';
 import type { NextFunction, Request, Response } from 'express';
-import { readFileSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import { extname, join } from 'path';
 import webpack, { Configuration } from 'webpack';
 import { lookup } from '../compiled/mrmime';
@@ -84,13 +85,35 @@ export class MFSU {
     // entry
     const entry: Record<string, string> = {};
     const virtualModules: Record<string, string> = {};
-    for (const key of Object.keys(opts.config.entry!)) {
+    // ensure entry object type
+    const entryObject = lodash.isString(opts.config.entry)
+      ? { default: [opts.config.entry] }
+      : (opts.config.entry as Record<string, string[]>);
+    assert(
+      lodash.isPlainObject(entryObject),
+      `webpack config 'entry' value must be a string or an object.`,
+    );
+    for (const key of Object.keys(entryObject)) {
       const virtualPath = `./mfsu-virtual-entry/${key}.js`;
       const virtualContent: string[] = [];
       let index = 1;
       let hasDefaultExport = false;
-      // @ts-ignore
-      for (const entry of opts.config.entry![key]) {
+      const entryFiles = lodash.isArray(entryObject[key])
+        ? entryObject[key]
+        : ([entryObject[key]] as unknown as string[]);
+      for (let entry of entryFiles) {
+        // ensure entry is a file
+        if (statSync(entry).isDirectory()) {
+          const realEntry = tryPaths([
+            join(entry, 'index.tsx'),
+            join(entry, 'index.ts'),
+          ]);
+          assert(
+            realEntry,
+            `entry file not found, please configure the specific entry path. (e.g. 'src/index.tsx')`,
+          );
+          entry = realEntry;
+        }
         const content = readFileSync(entry, 'utf-8');
         const [_imports, exports] = await parseModule({ content, path: entry });
         if (exports.length) {

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -200,6 +200,9 @@ promise new Promise(resolve => {
       ],
     );
 
+    // ensure topLevelAwait enabled
+    lodash.set(opts.config, 'experiments.topLevelAwait', true);
+
     /**
      * depConfig
      */

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -30,6 +30,7 @@ export * from './importLazy';
 export * from './npmClient';
 export * from './randomColor/randomColor';
 export * as register from './register';
+export * from './tryPaths';
 export * from './winPath';
 export {
   address,

--- a/packages/utils/src/tryPaths.ts
+++ b/packages/utils/src/tryPaths.ts
@@ -1,0 +1,7 @@
+import { existsSync } from 'fs';
+
+export function tryPaths(paths: string[]) {
+  for (const path of paths) {
+    if (existsSync(path)) return path;
+  }
+}


### PR DESCRIPTION

1. 尝试兼容了更多独立的 mfsu entry 配置方法，让对外使用者不容易踩坑

2. [`sorrycc/example-webpack-mfsu`](https://github.com/sorrycc/example-webpack-mfsu) 的 mfsu 版本旧了且一些使用姿势过时了，故把独立使用 mfsu 的 case 拿进来单独照顾

