### PR TITLE
plugin(tailwindcss): Write generated css file into .umi folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 /examples/*/.esmi
 /examples/*/.mfsu
-/examples/*/.tailwind
 /examples/*/.umi
 /examples/*/.umi-production
 /examples/*/src/.umi

--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -7,7 +7,7 @@ export default (api: IApi) => {
 
   api.onStart(() => {
     const inputPath = path.resolve(api.cwd, 'tailwind.css');
-    const generatedPath = path.resolve(api.cwd, '.tailwind/output.css');
+    const generatedPath = path.resolve(api.paths.absTmpPath, 'tailwind.css');
     const binPath = path.resolve(api.cwd, 'node_modules/.bin/tailwind');
 
     /** 透过子进程建立 tailwindcss 服务，将生成的 css 写入 generatedPath */


### PR DESCRIPTION
根据 https://github.com/umijs/umi-next/pull/281#discussion_r787745177 的建议将插件生成的临时样式文件写入 `api.paths.absTmpPath` 内。