### PR TITLE
fix(husky): husky v7 commit msg verify

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install esno scripts/verifyCommit.ts
+npx --no-install esno scripts/verifyCommit.ts $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install lint-staged
+npx --no-install lint-staged --quiet

--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -1,6 +1,6 @@
 import 'zx/globals';
 
-const msgPath = process.env.GIT_PARAMS as string;
+const msgPath = process.argv[2];
 if (!msgPath) process.exit();
 
 const msg = fs.readFileSync(msgPath, 'utf-8').trim();


### PR DESCRIPTION
修复了 husky 对 commit-msg 格式的校验。

1. husky v7 废弃了 `GIT_PARAMS` 和 `HUSKY_GIT_PARAMS`，取而代之应使用 `$1` 传递，详见 [Breaking changes](https://typicode.github.io/husky/#/?id=breaking-changes)

2. 兼容了命令行和 vscode scm 可视化提交两种报错信息的正确弹出：

    <img src='https://user-images.githubusercontent.com/59400654/150305014-2f7469cd-09a8-41f8-9103-bf1c925800ac.png' width='60%' />

    <br>
    <br>

    <img src='https://user-images.githubusercontent.com/59400654/150305156-19d9fa41-dfa7-4672-90a4-6c44650989bc.png' width='30%' />


