### PR TITLE
feat: container-query-polyfill plugin

### DIFF
--- a/packages/plugins/src/container-query-polyfill.ts
+++ b/packages/plugins/src/container-query-polyfill.ts
@@ -1,0 +1,18 @@
+import { IApi } from 'umi';
+
+export default (api: IApi) => {
+  api.describe({ key: 'container-query-polyfill' });
+
+  /** https://www.skypack.dev/view/container-query-polyfill */
+  api.addHTMLHeadScripts(() => [
+    `
+// Support Test
+const supportsContainerQueries = "container" in document.documentElement.style;
+
+// Conditional Import
+if (!supportsContainerQueries) {
+  import("https://cdn.skypack.dev/container-query-polyfill");
+}
+`,
+  ]);
+};


### PR DESCRIPTION
`plugin-container-query-polyfill` 将 [container-query-polyfill](https://www.skypack.dev/view/container-query-polyfill) 补丁进行封装，Umi 项目只要简单安装该插件就能在浏览器中使用 css 的 [Container Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries) 功能。