### PR TITLE
feat(plugin-docs): Added dark mode

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -10,7 +10,7 @@ export default () => {
   return (
     <div
       className="w-full flex flex-row items-center justify-between
-      border-b-gray-100 border-b-2 pt-4 pb-4 px-8"
+      border-b-gray-100 border-b-2 pt-4 pb-4 px-8 dark:border-b-gray-800"
     >
       <Logo />
       <div className="flex flex-row items-center">

--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -46,7 +46,7 @@ interface HamburgerButtonProps {
 
 function HamburgerButton(props: HamburgerButtonProps) {
   const barClass =
-    'block absolute h-0.5 w-5 bg-current transform' +
+    'block absolute h-0.5 w-5 bg-current transform dark:bg-white' +
     ' transition duration-500 ease-in-out';
 
   return (

--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -19,17 +19,17 @@ export default () => {
     <div>
       <div
         className="w-24 rounded-lg overflow-hidden cursor-pointer border
-       border-white hover:border-gray-100"
+       border-white hover:border-gray-100 dark:border-gray-800"
         onClick={() => setExpanded((e) => !e)}
       >
-        <p className="px-2 py-1">
+        <p className="px-2 py-1 dark:text-white">
           {languages.find((l) => l.value === currentLang)?.name || 'English'}
         </p>
       </div>
       <div
         className={
           'absolute transition-all duration-300 bottom-[-12] w-24 rounded-lg' +
-          ' cursor-pointer shadow overflow-hidden' +
+          ' cursor-pointer shadow overflow-hidden ' +
           (isExpanded ? ` max-h-${(languages.length - 1) * 12}` : ' max-h-0 ')
         }
       >
@@ -38,7 +38,7 @@ export default () => {
           .map((lang) => (
             <p
               key={lang.value}
-              className="p-2 bg-white hover:bg-gray-50 transition duration-300"
+              className="p-2 bg-white dark:bg-gray-700 dark:text-white hover:bg-gray-50 transition duration-300"
             >
               {lang.name}
             </p>

--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -59,7 +59,7 @@ export default (props: any) => {
 
       <div
         className={cx(
-          'fixed top-12 w-screen bg-white z-20',
+          'fixed top-12 w-screen bg-white z-20 dark:bg-gray-800',
           'overflow-hidden transition-all duration-500',
           isMenuOpened ? 'max-h-screen' : 'max-h-0',
         )}

--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -14,10 +14,10 @@ export default (props: any) => {
         location: props.location,
       }}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col dark:bg-gray-900 min-h-screen transition-all">
         <div
-          className="z-30 sticky top-0 before:bg-white before:bg-opacity-[.85]
-           before:backdrop-blur-md before:absolute before:block
+          className="z-30 sticky top-0 dark:before:bg-gray-800 before:bg-white before:bg-opacity-[.85]
+           before:backdrop-blur-md before:absolute before:block dark:before:bg-opacity-[.85]
            before:w-full before:h-full before:z-[-1]"
         >
           <Head />

--- a/packages/plugin-docs/client/theme-doc/Logo.tsx
+++ b/packages/plugin-docs/client/theme-doc/Logo.tsx
@@ -9,7 +9,9 @@ export default () => {
     <a href="/">
       <div className="flex flex-row items-center">
         <img src={logo} className="w-8 h-8" alt="logo" />
-        <div className="text-xl font-extrabold ml-2">{themeConfig.title}</div>
+        <div className="text-xl font-extrabold ml-2 dark:text-white">
+          {themeConfig.title}
+        </div>
       </div>
     </a>
   );

--- a/packages/plugin-docs/client/theme-doc/NavBar.tsx
+++ b/packages/plugin-docs/client/theme-doc/NavBar.tsx
@@ -7,7 +7,7 @@ export default () => {
     <ul className="flex">
       {themeConfig.navs.map((nav: any) => {
         return (
-          <li key={nav.path} className="ml-4">
+          <li key={nav.path} className="ml-4 dark:text-white">
             <components.Link to={nav.path}>{nav.title}</components.Link>
           </li>
         );

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -14,7 +14,8 @@ export default () => {
     <div
       className="rounded-lg w-64 flex items-center pr-2 flex-row hover:bg-gray-50
      transition duration-300 bg-gray-100 border border-white focus-within:border-gray-100
-     focus-within:bg-white"
+     focus-within:bg-white dark:bg-gray-700 dark:border-gray-700
+     dark:focus-within:border-gray-700 dark:focus-within:bg-gray-800 dark:text-gray-100"
     >
       <input
         id="search-input"

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -71,7 +71,7 @@ export default () => {
             >
               <p
                 className="p-2 bg-white hover:bg-gray-50 transition
-                 duration-300 group-focus:bg-blue-200"
+                 duration-300 group-focus:bg-blue-200 dark:bg-gray-700"
               >
                 {r.path}
               </p>

--- a/packages/plugin-docs/client/theme-doc/Sidebar.tsx
+++ b/packages/plugin-docs/client/theme-doc/Sidebar.tsx
@@ -30,7 +30,9 @@ export default () => {
         return (
           <li key={item.title}>
             <div>
-              <p className="text-xl font-extrabold my-6">{item.title}</p>
+              <p className="text-xl font-extrabold my-6 dark:text-white">
+                {item.title}
+              </p>
               {item.children.map((child: any) => {
                 const to = `${matchedNav.path}/${child}`;
                 const id = to.slice(1);
@@ -42,7 +44,7 @@ export default () => {
                       key={child}
                       className="my-2 hover:text-blue-400 transition-all
                        bg-blue-50 text-blue-400 px-4 py-1
-                       rounded-lg cursor-default"
+                       rounded-lg cursor-default dark:bg-blue-900 dark:text-blue-200"
                     >
                       {title}
                     </div>
@@ -53,7 +55,7 @@ export default () => {
                   <components.Link to={`${matchedNav.path}/${child}`}>
                     <div
                       key={child}
-                      className="text-gray-700 my-2 hover:text-blue-400 transition-all px-4 py-1"
+                      className="text-gray-700 my-2 hover:text-blue-400 transition-all px-4 py-1 dark:text-blue-200 dark:hover:text-blue-400"
                     >
                       {title}
                     </div>

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -1,11 +1,37 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import MoonIcon from './icons/moon.png';
 import SunIcon from './icons/sun.png';
 
 export default () => {
-  const [toggle, setToggle] = useState(true);
+  const [toggle, setToggle] = useState<Boolean>();
 
   const toggleClass = ' transform translate-x-6';
+
+  useEffect(() => {
+    // 初始化，获取过去曾经设定过的主题，或是系统当前的主题
+    if (toggle === undefined) {
+      if (localStorage.getItem('theme') === 'dark') {
+        setToggle(false);
+        return;
+      }
+      if (localStorage.getItem('theme') === 'light') {
+        setToggle(true);
+        return;
+      }
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        setToggle(false);
+        return;
+      }
+    }
+
+    if (toggle) {
+      document.body.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    } else {
+      document.body.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    }
+  }, [toggle]);
 
   return (
     <div

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -21,6 +21,7 @@ export default () => {
         setToggle(false);
         return;
       }
+      setToggle(true);
     }
 
     if (toggle) {

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -15,13 +15,15 @@ export default () => {
       className="w-full lg:m-12 mb-12 border
       border-gray-100 p-8 rounded-xl z-20"
     >
-      <p className="text-lg font-extrabold">{route.titles[0].title}</p>
+      <p className="text-lg font-extrabold dark:text-white">
+        {route.titles[0].title}
+      </p>
       <ul>
         {titles.map((item: any) => {
           return (
             <li
-              className="mt-3 text-gray-600 cursor-pointer
-              hover:text-blue-500 transition duration-300"
+              className="mt-3 text-gray-600 cursor-pointer dark:text-gray-400
+              hover:text-blue-500 transition duration-300 dark:hover:text-blue-500"
             >
               <a href={'#' + item.title}>{item.title}</a>
             </li>

--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -3,56 +3,56 @@
 @tailwind utilities;
 
 article h1 {
-  @apply text-4xl font-bold tracking-tight mt-2 my-4;
+  @apply text-4xl font-bold tracking-tight mt-2 my-4 dark:text-white;
 }
 
 article h2 {
-  @apply text-3xl font-semibold tracking-tight mt-10;
+  @apply text-3xl font-semibold tracking-tight mt-10 dark:text-white;
   @apply pb-1 border-b;
 }
 
 article h3 {
-  @apply text-2xl font-semibold tracking-tight mt-8;
+  @apply text-2xl font-semibold tracking-tight mt-8 dark:text-white;
 }
 
 article h4 {
-  @apply text-xl font-semibold tracking-tight mt-8;
+  @apply text-xl font-semibold tracking-tight mt-8 dark:text-white;
 }
 
 article h5 {
-  @apply text-lg font-semibold tracking-tight mt-8;
+  @apply text-lg font-semibold tracking-tight mt-8 dark:text-white;
 }
 
 article h6 {
-  @apply text-base font-semibold tracking-tight mt-8;
+  @apply text-base font-semibold tracking-tight mt-8 dark:text-white;
 }
 
 article p {
-  @apply text-base font-light leading-8 mt-4 text-gray-700;
+  @apply text-base font-light leading-8 mt-4 text-gray-700 dark:text-white;
 }
 
 article ul {
-  @apply list-disc ml-6 mt-6;
+  @apply list-disc ml-6 mt-6 dark:text-white;
 }
 
 article li {
-  @apply mt-2;
+  @apply mt-2 dark:text-white;
 }
 
 article ol {
-  @apply list-decimal ml-6 mt-6;
+  @apply list-decimal ml-6 mt-6 dark:text-white;
 }
 
 article blockquote {
-  @apply italic pl-6 border-l-2 border-gray-300 text-gray-700;
+  @apply italic pl-6 border-l-2 border-gray-300 text-gray-700 dark:text-white;
 }
 
 article h2 a {
-  @apply no-underline;
+  @apply no-underline dark:text-white;
 }
 
 article code {
-  @apply bg-black bg-opacity-5 border border-black border-opacity-5 rounded-md;
+  @apply bg-black bg-opacity-5 border border-black border-opacity-5 rounded-md dark:text-white;
   font-size: 0.9em;
   padding: 2px 0.25em;
   box-decoration-break: clone;
@@ -60,31 +60,31 @@ article code {
 }
 
 article inlinecode {
-  @apply bg-black bg-opacity-5 border border-black border-opacity-5 rounded-md px-1.5 py-0.5 text-xs;
+  @apply bg-black bg-opacity-5 border border-black border-opacity-5 rounded-md px-1.5 py-0.5 text-xs dark:text-white dark:bg-gray-700;
 }
 
 article pre {
   /* content-visibility: auto; */
   contain: paint;
-  @apply p-4 bg-slate-100 rounded-xl my-8 overflow-x-auto font-medium subpixel-antialiased;
+  @apply p-4 bg-slate-100 dark:bg-slate-800 rounded-xl my-8 overflow-x-auto font-medium subpixel-antialiased dark:text-white;
 }
 
 article pre code {
   line-height: 1.25rem;
-  @apply relative p-0 text-sm text-current bg-transparent rounded-none border-none inline-block min-w-full;
+  @apply relative p-0 text-sm text-current bg-transparent rounded-none border-none inline-block min-w-full dark:text-white;
 }
 
 article pre code .line.highlighted {
-  @apply before:block before:absolute before:h-5 before:bg-gray-500 before:bg-opacity-10 before:-inset-x-4 before:pointer-events-none before:select-none;
+  @apply before:block before:absolute before:h-5 before:bg-gray-500 before:bg-opacity-10 before:-inset-x-4 before:pointer-events-none before:select-none dark:text-white;
 }
 
 article a code {
-  @apply text-current no-underline;
+  @apply text-current no-underline dark:text-white;
 }
 
 article a {
-  @apply text-blue-600 mx-1 hover:text-blue-300 transition;
-  background-image: linear-gradient(#fff 60%, rgba(130, 199, 255, 0.28) 55%);
+  @apply text-blue-600 mx-1 hover:text-blue-300 transition dark:text-blue-400;
+  background-image: linear-gradient(transparent 60%, rgba(130, 199, 255, 0.28) 55%);
 }
 
 /*article pre {*/

--- a/packages/plugin-docs/tailwind.config.js
+++ b/packages/plugin-docs/tailwind.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   content: ['./client/theme-doc/*.tsx'],
+  darkMode: 'class'
 };


### PR DESCRIPTION
帮 `plugin-docs` 增加了暗黑模式：

![Screen Recording 2022-01-24 at 7 55 43 PM](https://user-images.githubusercontent.com/21105863/150779046-f364b330-8fee-4934-9ee0-8d5447140247.gif)

启用逻辑：
- 若用户曾经访问过网站，会开启他上次选择的主题 (localstorage)
- 若用户不曾访问过网站，会开启他当前操作系统选择的主题 (prefers-color-scheme)
