### PR TITLE
feat(mfsu): support user define want replace env var

### DIFF
--- a/packages/bundler-esbuild/src/build.ts
+++ b/packages/bundler-esbuild/src/build.ts
@@ -62,6 +62,7 @@ export async function build(opts: IOpts) {
       // __dirname sham
       __dirname: JSON.stringify('__dirname'),
       'process.env.NODE_ENV': JSON.stringify(opts.mode || 'development'),
+      ...opts.config.define,
     },
     loader: {
       '.svg': 'dataurl',


### PR DESCRIPTION
外部独立使用 mfsu + 采用 esbuild 打包第三方库时，类似自定义的 `process.env.*` 环境变量无法被替换，这里支持下用户自配置。