### PR TITLE
feat(plugin-docs): Added mdx Message component for docs

### DIFF
--- a/packages/plugin-docs/client/theme-doc/components/Message.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Message.tsx
@@ -1,0 +1,45 @@
+import React, { PropsWithChildren } from "react"
+
+enum MessageType {
+  Info = "info",
+  Success = "success",
+  Warning = "warning",
+  Error = "error",
+}
+
+interface MessageProps {
+  type?: MessageType
+  emoji?: string
+}
+
+function Message(props: PropsWithChildren<MessageProps>) {
+  let bgColor = 'bg-blue-50';
+  let textColor = 'text-blue-900';
+
+  switch (props.type) {
+    case MessageType.Success:
+      bgColor = 'bg-green-50';
+      textColor = 'text-green-900';
+      break;
+    case MessageType.Warning:
+      bgColor = 'bg-orange-50';
+      textColor = 'text-orange-900';
+      break;
+    case MessageType.Error:
+      bgColor = 'bg-red-50';
+      textColor = 'text-red-900';
+      break;
+  }
+
+  return <>
+    <div
+      className={`w-full py-3 px-4 ${bgColor} ${textColor} rounded-lg my-2`}>
+      {props.emoji && <span role="img" className="mr-3">
+        {props.emoji}
+      </span>}
+      {props.children}
+    </div>
+  </>
+}
+
+export default Message

--- a/packages/plugin-docs/client/theme-doc/index.ts
+++ b/packages/plugin-docs/client/theme-doc/index.ts
@@ -1,2 +1,5 @@
 import './tailwind.out.css';
 export { default as Layout } from './Layout';
+
+// Components
+export { default as Message } from './components/Message';

--- a/packages/plugin-docs/src/index.ts
+++ b/packages/plugin-docs/src/index.ts
@@ -64,6 +64,13 @@ export default (api: IApi) => {
       });
     }
 
+    // @TODO: 需要能够动态解析 theme 中导出的组件，现在是硬编码
+    api.writeTmpFile({
+      path: 'index.ts', content: `
+export { Message } from '${require.resolve('../client/theme-doc')}';
+    `
+    });
+
     api.writeTmpFile({
       path: 'Layout.tsx',
       content: `

--- a/packages/plugin-docs/tailwind.config.js
+++ b/packages/plugin-docs/tailwind.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  content: ['./client/theme-doc/*.tsx'],
+  content: ['./client/theme-doc/**/*.tsx'],
   darkMode: 'class'
 };


### PR DESCRIPTION
在 plugin-docs 加入了 Message 组件，使用方式：在 mdx 文件中加入

```tsx
import { Message } from 'umi';
```

即可使用 Message 组件。

<img width="1552" alt="Screen Shot 2022-01-26 at 12 20 46 PM" src="https://user-images.githubusercontent.com/21105863/151103561-d59a81a3-5297-4c7a-9e71-d229719211e4.png">

<img width="1552" alt="Screen Shot 2022-01-26 at 12 21 02 PM" src="https://user-images.githubusercontent.com/21105863/151103567-c3d124ff-d929-454f-b6be-d844746820cb.png">


