### PR TITLE
fix(plugin-docs): Fixed TOC link bug and nested headings style

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
 
+function getLinkFromTitle(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/[（）]/g, '');
+}
+
 export default () => {
   const { location, appData } = useThemeContext()!;
   const lang = useLanguage();
@@ -31,10 +38,16 @@ export default () => {
         {titles.map((item: any) => {
           return (
             <li
+              style={{ paddingLeft: `${item.level - 2}rem` }}
               className="mt-3 text-gray-600 cursor-pointer dark:text-gray-400
               hover:text-blue-500 transition duration-300 dark:hover:text-blue-500"
             >
-              <a href={'#' + item.title}>{item.title}</a>
+              <a
+                className={item.level > 2 ? 'text-sm' : ''}
+                href={'#' + getLinkFromTitle(item.title)}
+              >
+                {item.title}
+              </a>
             </li>
           );
         })}


### PR DESCRIPTION
1. 修复了 plugin-docs 中 TOC 在标题有大写英文字母、空格或全形括号时会无法跳转的问题。
2. 修复了 plugin-docs 中 TOC 对多级标题没有区分样式的问题