### PR TITLE
fix(plugin-docs): Fixed GitHub icon color in dark mode

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Github.tsx
+++ b/packages/plugin-docs/client/theme-doc/Github.tsx
@@ -12,7 +12,7 @@ export default () => {
 
   return (
     <a href={ctx.themeConfig.github}>
-      <img src={GithubIcon} alt="Github" />
+      <img className="dark:invert" src={GithubIcon} alt="Github" />
     </a>
   );
 };


### PR DESCRIPTION
修复了 `plugin-docs` 中黑暗模式的 GitHub 图标颜色问题

<img width="639" alt="Screen Shot 2022-01-26 at 2 28 50 PM" src="https://user-images.githubusercontent.com/21105863/151114346-18665cea-f4f0-49eb-bf07-fdca3e75aaf5.png">

