### PR TITLE
fix(plugin-docs): Fixed anchor not working in first load

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ThemeContext } from './context';
 import Head from './Head';
 import Sidebar from './Sidebar';
@@ -7,6 +7,16 @@ import Toc from './Toc';
 
 export default (props: any) => {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
+
+  useEffect(() => {
+    if (window.location.hash.length !== 0) {
+      const hash = window.location.hash;
+      window.location.hash = '';
+      setTimeout(() => {
+        window.location.hash = hash;
+      }, 500);
+    }
+  }, []);
 
   return (
     <ThemeContext.Provider


### PR DESCRIPTION
修复了 plugin-docs 手动访问带锚点的链接时没有跳转到指定位置的问题