### PR TITLE
fix(plugin-docs): Removed fadeout effect on TOC

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -34,7 +34,7 @@ export default () => {
       <p className="text-lg font-extrabold dark:text-white">
         {route.titles[0].title}
       </p>
-      <ul className="max-h-[calc(100vh-360px)] overflow-y-scroll fadeout py-2">
+      <ul className="max-h-[calc(100vh-360px)] overflow-y-scroll py-2">
         {titles.map((item: any) => {
           return (
             <li


### PR DESCRIPTION
将 plugin-docs 中 TOC 的上下淡出效果移除，避免影响阅读。

上下淡出本来是想暗示用户可以滚动，避免内容太多的情况下用户不知道下面还有内容，
但如果要避免影响阅读的话可能要监听当前的滚动位置来动态调节淡出效果的透明度，
但刚刚试了一下 react 的 style 好像还不支持 maskImage 传入 linear-gradient 的值，
所以不太好实现，因此先将样式直接移除。