### PR TITLE
feat(plugin-docs): Improved user experience in switching language

### DIFF
--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -9,12 +9,25 @@ export default () => {
     return null;
   }
 
+  function handleClick() {
+    if (!currentLanguage) return;
+    if (languages.length === 2) {
+      switchLanguage(
+        languages[0].locale === currentLanguage.locale
+          ? languages[1].locale
+          : languages[0].locale,
+      );
+      return;
+    }
+    setExpanded((e) => !e);
+  }
+
   return (
     <div>
       <div
         className="w-24 rounded-lg overflow-hidden cursor-pointer border
        border-white hover:border-gray-100 dark:border-gray-800"
-        onClick={() => setExpanded((e) => !e)}
+        onClick={handleClick}
       >
         <p className="px-2 py-1 dark:text-white">{currentLanguage.text}</p>
       </div>

--- a/packages/plugin-docs/client/theme-doc/useLanguage.ts
+++ b/packages/plugin-docs/client/theme-doc/useLanguage.ts
@@ -47,7 +47,7 @@ function useLanguage(): useLanguageResult {
     }
 
     let p = location.pathname.split('/');
-    p[0] = locale;
+    p[1] = locale;
     window.location.pathname = p.join('/');
   }
 


### PR DESCRIPTION
1. 如果 theme.config.js 的 i18n 只设置了两个语言，则右上角的语言选单会改为点击直接切换，不需要下拉选择
2. 修复了当切换语言时，若两个语言都是不是默认语言，会跳转到错误路径的问题