### PR TITLE
fix(antd-pro): lib dev deps effect

### DIFF
--- a/examples/ant-design-pro/package.json
+++ b/examples/ant-design-pro/package.json
@@ -25,5 +25,10 @@
     "numeral": "^2.0.6",
     "querystring": "^0.2.1",
     "rc-util": "^5.16.1"
+  },
+  "dependenciesMeta": {
+    "@umijs/pro": {
+      "injected": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "umi": "workspace:*",
     "zx": "^4.2.0"
   },
-  "packageManager": "pnpm"
+  "packageManager": "pnpm",
+  "engines": {
+    "node": ">=14",
+    "pnpm": ">=6.20"
+  }
 }


### PR DESCRIPTION
解决开发依赖污染导致项目跑不起来的问题。

使用 `dependenciesMeta` 让依赖表现的像一个真实的 npm 包，不再携带 `node_modules` 造成依赖寻路污染。

https://pnpm.io/zh/package_json#dependenciesmeta