### PR TITLE
feat(esbuild): support use esbuild transpiler with mfsu mode

### DIFF
--- a/examples/mfsu-independent/README.md
+++ b/examples/mfsu-independent/README.md
@@ -2,11 +2,11 @@
 
 Start the antd + framer-motion project without cache in one second.
 
-![](https://img.alicdn.com/imgextra/i2/O1CN01k8Gjoo1P5rgMGHuuC_!!6000000001790-2-tps-1204-378.png)
+<img src='https://img.alicdn.com/imgextra/i2/O1CN01k8Gjoo1P5rgMGHuuC_!!6000000001790-2-tps-1204-378.png' width='70%' />
 
 ## Setup
 
-Install dependency with pnpm or yarn or npm,
+Install dependency with pnpm.
 
 ```bash
 $ pnpm install
@@ -15,14 +15,11 @@ $ pnpm install
 Start dev server,
 
 ```bash
+# start babel transpiler example
 $ pnpm dev
-<i> [webpack-dev-server] Project is running at:
-<i> [webpack-dev-server] Loopback: http://localhost:8080/
-<i> [webpack-dev-server] On Your Network (IPv4): http://30.230.88.77:8080/
-<i> [webpack-dev-server] On Your Network (IPv6): http://[fe80::1]:8080/
-webpack 5.64.4 compiled successfully in 638 ms
-webpack 5.64.4 compiled successfully in 59 ms
-event - [mfsu] compiled with esbuild successfully in 293 ms
+
+# start esbuild transpiler example
+$ pnpm dev:esbuild
 ```
 
 ## LICENSE

--- a/examples/mfsu-independent/package.json
+++ b/examples/mfsu-independent/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "build": "webpack",
-    "dev": "webpack-dev-server",
-    "start": "npm run dev"
+    "dev": "webpack serve --config webpack.config.js",
+    "dev:esbuild": "webpack serve --config webpack.config.esbuild.js"
   },
   "dependencies": {},
   "devDependencies": {
@@ -12,7 +12,8 @@
     "@babel/preset-typescript": "^7.16.0",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "@umijs/mfsu": "4.0.0-beta.16",
+    "@umijs/bundler-webpack": "4.0.0-beta.18",
+    "@umijs/mfsu": "4.0.0-beta.18",
     "antd": "^4.17.2",
     "babel-loader": "^8.2.3",
     "framer-motion": "^5.3.3",

--- a/examples/mfsu-independent/webpack.config.esbuild.js
+++ b/examples/mfsu-independent/webpack.config.esbuild.js
@@ -1,0 +1,73 @@
+const path = require('path')
+const webpack = require('webpack');
+const { MFSU } = require('@umijs/mfsu');
+const { esbuildLoaderPath } = require('@umijs/bundler-webpack/dist/loader/esbuild')
+
+// [mfsu] 1. init instance
+const mfsu = new MFSU({
+  implementor: webpack,
+  buildDepWithESBuild: true,
+});
+
+const config = {
+  entry: path.join(__dirname, './src'),
+  mode: 'development',
+  output: {
+    path: path.join(__dirname, './dist'),
+    filename: 'bundle.js',
+    publicPath: '/'
+  },
+  devServer: {
+    // [mfsu] 2. add mfsu middleware
+    setupMiddlewares(middlewares, devServer) {
+      middlewares.unshift(
+        ...mfsu.getMiddlewares()
+      )
+      return middlewares
+    },
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.[jt]sx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: esbuildLoaderPath,
+          options: {
+            handler: [
+              // [mfsu] 3. add mfsu esbuild loader handlers
+              ...mfsu.getEsbuildLoaderHandler()
+            ],
+            target: 'esnext'
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new (require('html-webpack-plugin'))({
+      template: path.resolve(__dirname, './index.html')
+    })
+  ],
+  stats: {
+    assets: false,
+    moduleAssets: false,
+    runtime: false,
+    runtimeModules: false,
+    modules: false,
+    entrypoints: false,
+  },
+};
+
+// [mfsu] 4. inject mfsu webpack config
+const getConfig = async () => {
+  await mfsu.setWebpackConfig({
+    config,
+  });
+  return config
+}
+
+module.exports = getConfig();

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -29,6 +29,7 @@ export interface IOpts {
   entry: Record<string, string>;
   extraBabelPresets?: any[];
   extraBabelPlugins?: any[];
+  extraEsbuildLoaderHandler?: any[];
   babelPreset?: any;
   chainWebpack?: Function;
   modifyWebpackConfig?: Function;
@@ -62,6 +63,7 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
     babelPreset: opts.babelPreset,
     extraBabelPlugins: opts.extraBabelPlugins || [],
     extraBabelPresets: opts.extraBabelPresets || [],
+    extraEsbuildLoaderHandler: opts.extraEsbuildLoaderHandler || [],
     browsers: getBrowsersList({
       targets: userConfig.targets,
     }),

--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -3,6 +3,7 @@ import { chalk } from '@umijs/utils';
 import { ProvidePlugin } from '../../compiled/webpack';
 import Config from '../../compiled/webpack-5-chain';
 import { MFSU_NAME } from '../constants';
+import autoCssModulesHandler from '../esbuildHandler/autoCssModules';
 import { esbuildLoaderPath } from '../loader/esbuild';
 import AutoCSSModule from '../swcPlugins/autoCSSModules';
 import { Env, IConfig, Transpiler } from '../types';
@@ -128,7 +129,7 @@ export async function addJavaScriptRules(opts: IOpts) {
         .loader(esbuildLoaderPath)
         .options({
           target: isDev ? 'esnext' : 'es2015',
-          handler: opts.extraEsbuildLoaderHandler,
+          handler: [autoCssModulesHandler, ...opts.extraEsbuildLoaderHandler],
         });
       // esbuild loader can not auto import `React`
       config.plugin('react-provide-plugin').use(ProvidePlugin, [

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -51,6 +51,7 @@ export async function dev(opts: IOpts) {
       ...(opts.beforeBabelPresets || []),
       ...(opts.extraBabelPresets || []),
     ],
+    extraEsbuildLoaderHandler: [],
     chainWebpack: opts.chainWebpack,
     modifyWebpackConfig: opts.modifyWebpackConfig,
     hmr: true,

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -51,7 +51,7 @@ export async function dev(opts: IOpts) {
       ...(opts.beforeBabelPresets || []),
       ...(opts.extraBabelPresets || []),
     ],
-    extraEsbuildLoaderHandler: [],
+    extraEsbuildLoaderHandler: mfsu?.getEsbuildLoaderHandler() || [],
     chainWebpack: opts.chainWebpack,
     modifyWebpackConfig: opts.modifyWebpackConfig,
     hmr: true,

--- a/packages/bundler-webpack/src/esbuildHandler/autoCssModules.ts
+++ b/packages/bundler-webpack/src/esbuildHandler/autoCssModules.ts
@@ -1,0 +1,30 @@
+import { isStyleFile } from '@umijs/utils';
+import { IEsbuildLoaderHandlerParams } from '../types';
+
+const CSS_MODULES_QUERY = '?modules';
+const QUERY_LENGTH = CSS_MODULES_QUERY.length;
+
+export default function autoCssModulesHandler(
+  opts: IEsbuildLoaderHandlerParams,
+) {
+  let { code } = opts;
+
+  let offset = 0;
+  opts.imports.forEach((i) => {
+    if (i.d < 0 && isStyleFile({ filename: i.n })) {
+      // import x from './index.less'
+      //   => import x from '
+      const importSegment = code.substring(i.ss + offset, i.s + offset);
+      // is css module
+      if (~importSegment.indexOf(' from')) {
+        code = `${code.substring(
+          0,
+          i.e + offset,
+        )}${CSS_MODULES_QUERY}${code.substring(i.e + offset)}`;
+        offset += QUERY_LENGTH;
+      }
+    }
+  });
+
+  return code;
+}

--- a/packages/bundler-webpack/src/index.ts
+++ b/packages/bundler-webpack/src/index.ts
@@ -3,3 +3,4 @@ export * from './build';
 export * from './config/config';
 export * from './dev';
 export * from './schema';
+export type { IEsbuildLoaderHandlerParams } from './types';

--- a/packages/bundler-webpack/src/index.ts
+++ b/packages/bundler-webpack/src/index.ts
@@ -3,4 +3,3 @@ export * from './build';
 export * from './config/config';
 export * from './dev';
 export * from './schema';
-export type { IEsbuildLoaderHandlerParams } from './types';

--- a/packages/bundler-webpack/src/loader/esbuild.ts
+++ b/packages/bundler-webpack/src/loader/esbuild.ts
@@ -1,0 +1,47 @@
+import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
+import {
+  Loader as EsbuildLoader,
+  transform,
+} from '@umijs/bundler-utils/compiled/esbuild';
+import { extname } from 'path';
+import type { LoaderContext } from '../../compiled/webpack';
+import type { IEsbuildLoaderOpts } from '../types';
+
+async function esbuildLoader(
+  this: LoaderContext<IEsbuildLoaderOpts>,
+  source: string,
+): Promise<void> {
+  const done = this.async();
+  const options: IEsbuildLoaderOpts = this.getOptions();
+  const { handler = [], ...otherOptions } = options;
+
+  const filePath = this.resourcePath;
+  const ext = extname(filePath).slice(1) as EsbuildLoader;
+
+  const transformOptions = {
+    ...otherOptions,
+    target: options.target ?? 'es2015',
+    loader: ext ?? 'js',
+    sourcemap: this.sourceMap,
+    sourcefile: filePath,
+  };
+
+  try {
+    let { code, map } = await transform(source, transformOptions);
+
+    if (handler.length) {
+      await init;
+      const [imports, exports] = parse(code);
+      handler.forEach((handle) => {
+        code = handle({ code, imports, exports, filePath });
+      });
+    }
+
+    done(null, code, map && JSON.parse(map));
+  } catch (error: unknown) {
+    done(error as Error);
+  }
+}
+
+export default esbuildLoader;
+export const esbuildLoaderPath = __filename;

--- a/packages/bundler-webpack/src/loader/esbuild.ts
+++ b/packages/bundler-webpack/src/loader/esbuild.ts
@@ -31,8 +31,8 @@ async function esbuildLoader(
 
     if (handler.length) {
       await init;
-      const [imports, exports] = parse(code);
       handler.forEach((handle) => {
+        const [imports, exports] = parse(code);
         code = handle({ code, imports, exports, filePath });
       });
     }

--- a/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
+++ b/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
@@ -1,8 +1,6 @@
 import { ImportDeclaration, TsType, VariableDeclaration } from '@swc/core';
 import Visitor from '@swc/core/Visitor';
-import { extname } from 'path';
-
-const CSS_EXT_NAMES = ['.css', '.less', '.sass', '.scss', '.stylus', '.styl'];
+import { isStyleFile } from '@umijs/utils';
 
 class AutoCSSModule extends Visitor {
   visitTsType(expression: TsType) {
@@ -13,7 +11,7 @@ class AutoCSSModule extends Visitor {
     const { specifiers, source } = expression;
     const { value } = source;
 
-    if (specifiers.length && CSS_EXT_NAMES.includes(extname(value))) {
+    if (specifiers.length && isStyleFile({ filename: value })) {
       return {
         ...expression,
         source: {
@@ -36,9 +34,9 @@ class AutoCSSModule extends Visitor {
       declarations[0].init.argument.type === 'CallExpression' &&
       declarations[0].init.argument.arguments[0].expression.type ===
         'StringLiteral' &&
-      CSS_EXT_NAMES.includes(
-        extname(declarations[0].init.argument.arguments[0].expression.value),
-      )
+      isStyleFile({
+        filename: declarations[0].init.argument.arguments[0].expression.value,
+      })
     ) {
       declarations[0].init.argument.arguments[0].expression.value = `${declarations[0].init.argument.arguments[0].expression.value}?modules`;
     }

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -1,4 +1,6 @@
 import type { Config as SwcConfig } from '@swc/core';
+import type { ImportSpecifier } from '@umijs/bundler-utils/compiled/es-module-lexer';
+import type { TransformOptions } from '@umijs/bundler-utils/compiled/esbuild';
 import type { Options as ProxyOptions } from '../compiled/http-proxy-middleware';
 import { Configuration } from '../compiled/webpack';
 import Config from '../compiled/webpack-5-chain';
@@ -77,4 +79,14 @@ export interface IConfig {
 export interface SwcOptions extends SwcConfig {
   sync?: boolean;
   parseMap?: boolean;
+}
+
+export interface IEsbuildLoaderHandlerParams {
+  code: string;
+  filePath: string;
+  imports: readonly ImportSpecifier[];
+  exports: readonly string[];
+}
+export interface IEsbuildLoaderOpts extends Partial<TransformOptions> {
+  handler?: Array<(opts: IEsbuildLoaderHandlerParams) => string>;
 }

--- a/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
@@ -21,6 +21,7 @@ export function checkMatch({
   isExportAll,
   depth,
   cache,
+  filename,
 }: {
   value: string;
   path?: Babel.NodePath;
@@ -28,6 +29,7 @@ export function checkMatch({
   isExportAll?: boolean;
   depth?: number;
   cache?: Map<string, any>;
+  filename?: string;
 }): { isMatch: boolean; replaceValue: string } {
   let isMatch;
   let replaceValue = '';
@@ -74,6 +76,7 @@ export function checkMatch({
         isExportAll,
         depth: depth + 1,
         cache,
+        filename,
       });
     } else {
       isMatch = true;
@@ -89,7 +92,7 @@ export function checkMatch({
   }
 
   // @ts-ignore
-  const file = path?.hub.file.opts.filename;
+  const file = path?.hub.file.opts.filename || filename;
   opts.onTransformDeps?.({
     sourceValue: value,
     replaceValue,

--- a/packages/mfsu/src/esbuildHandlers/autoExport.ts
+++ b/packages/mfsu/src/esbuildHandlers/autoExport.ts
@@ -1,0 +1,8 @@
+import type { IEsbuildLoaderHandlerParams } from '@umijs/bundler-webpack';
+
+export default function autoExportHandler(opts: IEsbuildLoaderHandlerParams) {
+  if (!opts.exports.length) {
+    return `${opts.code};\nexport const __mfsu = 1;`;
+  }
+  return opts.code;
+}

--- a/packages/mfsu/src/esbuildHandlers/autoExport.ts
+++ b/packages/mfsu/src/esbuildHandlers/autoExport.ts
@@ -1,6 +1,9 @@
-import type { IEsbuildLoaderHandlerParams } from '@umijs/bundler-webpack';
+interface IOpts {
+  exports: string[];
+  code: string;
+}
 
-export default function autoExportHandler(opts: IEsbuildLoaderHandlerParams) {
+export default function autoExportHandler(opts: IOpts) {
   if (!opts.exports.length) {
     return `${opts.code};\nexport const __mfsu = 1;`;
   }

--- a/packages/mfsu/src/esbuildHandlers/awaitImport/index.ts
+++ b/packages/mfsu/src/esbuildHandlers/awaitImport/index.ts
@@ -1,4 +1,4 @@
-import type { IEsbuildLoaderHandlerParams } from '@umijs/bundler-webpack';
+import type { ImportSpecifier } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { checkMatch } from '../../babelPlugins/awaitImport/checkMatch';
 
 interface IParams {
@@ -6,8 +6,14 @@ interface IParams {
   opts: any;
 }
 
+interface IOpts {
+  code: string;
+  imports: ImportSpecifier[];
+  filePath: string;
+}
+
 export default function getAwaitImportHandler(params: IParams) {
-  return function awaitImportHandler(opts: IEsbuildLoaderHandlerParams) {
+  return function awaitImportHandler(opts: IOpts) {
     let offset = 0;
 
     let { code } = opts;

--- a/packages/mfsu/src/esbuildHandlers/awaitImport/index.ts
+++ b/packages/mfsu/src/esbuildHandlers/awaitImport/index.ts
@@ -1,0 +1,51 @@
+import type { IEsbuildLoaderHandlerParams } from '@umijs/bundler-webpack';
+import { checkMatch } from '../../babelPlugins/awaitImport/checkMatch';
+
+interface IParams {
+  cache: Map<string, any>;
+  opts: any;
+}
+
+export default function getAwaitImportHandler(params: IParams) {
+  return function awaitImportHandler(opts: IEsbuildLoaderHandlerParams) {
+    let offset = 0;
+
+    let { code } = opts;
+    const { filePath, imports } = opts;
+    imports.forEach((i) => {
+      if (!i.n) return;
+
+      const isLazyImport = i.d > 0;
+      const from = i.n;
+      const { isMatch, replaceValue } = checkMatch({
+        cache: params.cache,
+        value: from,
+        opts: params.opts,
+        filename: filePath,
+      });
+      if (isMatch) {
+        // case: import x from './index.ts';
+        //       import('./index.ts');
+
+        // import x from '
+        // import(
+        const preSeg = code.substring(0, i.s + offset);
+        // ';
+        // );
+        const tailSeg = code.substring(i.e + offset);
+        const quote = isLazyImport ? '"' : '';
+        code = `${preSeg}${quote}${replaceValue}${quote}${tailSeg}`;
+        offset += replaceValue.length - from.length;
+      }
+    });
+
+    if (params.cache.has(filePath)) {
+      params.opts.onCollect?.({
+        file: filePath,
+        data: params.cache.get(filePath),
+      });
+    }
+
+    return code;
+  };
+}

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -319,6 +319,6 @@ promise new Promise(resolve => {
         cache,
         opts: checkOpts,
       }),
-    ];
+    ] as any[];
   }
 }

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -23,6 +23,8 @@ import {
 import { Dep } from './dep/dep';
 import { DepBuilder } from './depBuilder/depBuilder';
 import { DepInfo } from './depInfo';
+import autoExportHandler from './esbuildHandlers/autoExport';
+import getAwaitImportHandler from './esbuildHandlers/awaitImport';
 import { Mode } from './types';
 import { makeArray } from './utils/makeArray';
 import { BuildDepPlugin } from './webpackPlugins/buildDepPlugin';
@@ -305,5 +307,18 @@ promise new Promise(resolve => {
 
   getBabelPlugins() {
     return [autoExport, [awaitImport, this.getAwaitImportCollectOpts()]];
+  }
+
+  getEsbuildLoaderHandler() {
+    const cache = new Map<string, any>();
+    const checkOpts = this.getAwaitImportCollectOpts();
+
+    return [
+      autoExportHandler,
+      getAwaitImportHandler({
+        cache,
+        opts: checkOpts,
+      }),
+    ];
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -27,6 +27,7 @@ import installDeps from './installDeps';
 import * as logger from './logger';
 import updatePackageJSON from './updatePackageJSON';
 export * from './importLazy';
+export * from './isStyleFile';
 export * from './npmClient';
 export * from './randomColor/randomColor';
 export * as register from './register';

--- a/packages/utils/src/isStyleFile.ts
+++ b/packages/utils/src/isStyleFile.ts
@@ -1,0 +1,20 @@
+import { extname } from 'path';
+
+export const AUTO_CSS_MODULE_EXTS = [
+  '.css',
+  '.less',
+  '.sass',
+  '.scss',
+  '.stylus',
+  '.styl',
+];
+
+export const isStyleFile = ({
+  filename,
+  ext,
+}: {
+  filename?: string;
+  ext?: string;
+}) => {
+  return AUTO_CSS_MODULE_EXTS.includes(ext ?? extname(filename!));
+};


### PR DESCRIPTION
这个 pr 做了几件事：

1. 新增 esbuild 模式支持 source 的 transipiler

2. 为了支持 mfsu 和 auto css module，重写了 mfsu 的 babel plugin 和 auto css modules 的 esbuild 转换版本

3. 新增一个 esbuild 作为 transpiler (esbuild-loader) 对外部独立使用的 webpack config 例子