### PR TITLE
chore(lang-identify): ignore deps file language detect

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/compiled/** linguist-vendored
+.husky/* linguist-vendored


### PR DESCRIPTION
忽略掉 预编译依赖 的语言识别，显示出仓库真正使用的编码语言占比。