### PR TITLE
chore(swc): improve swc loader polyfill

### DIFF
--- a/examples/tmp-swcTranspiler-swc/.umirc.ts
+++ b/examples/tmp-swcTranspiler-swc/.umirc.ts
@@ -1,4 +1,8 @@
 export default {
   srcTranspiler: 'swc',
-  mfsu: {},
+  targets: {
+    // chrome 53 is last not support async version
+    // https://caniuse.com/async-functions
+    chrome: 54,
+  },
 };

--- a/examples/tmp-swcTranspiler-swc/.umirc.ts
+++ b/examples/tmp-swcTranspiler-swc/.umirc.ts
@@ -1,5 +1,6 @@
 export default {
   srcTranspiler: 'swc',
+  mfsu: false,
   targets: {
     // chrome 53 is last not support async version
     // https://caniuse.com/async-functions

--- a/examples/tmp-swcTranspiler-swc/package.json
+++ b/examples/tmp-swcTranspiler-swc/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "build": "umi build",
     "dev": "umi dev",
     "start": "npm run dev"
   },

--- a/examples/tmp-swcTranspiler-swc/pages/index.tsx
+++ b/examples/tmp-swcTranspiler-swc/pages/index.tsx
@@ -7,5 +7,13 @@ import styles from './index.less';
 // const styles = await import('./index.less');
 
 export default function HomePage() {
+  // check async transpiler
+  const func = async () => {
+    // need inject polyfill `Array.flat` on production env
+    (window as any).a = [1, 2, 3].flat();
+  };
+
+  func();
+
   return <div className={styles.title}>HomePage</div>;
 }

--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -122,6 +122,7 @@ export async function addJavaScriptRules(opts: IOpts) {
         .loader(require.resolve('../loader/swc'))
         .options({
           plugin: (m: Program) => new AutoCSSModule().visitProgram(m),
+          targets: userConfig.targets,
         });
     } else if (srcTranspiler === Transpiler.esbuild) {
       rule

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -1,4 +1,5 @@
 import { MFSU, MF_DEP_PREFIX } from '@umijs/mfsu';
+import { logger } from '@umijs/utils';
 import { join } from 'path';
 import webpack from '../compiled/webpack';
 import { getConfig, IOpts as IConfigOpts } from './config/config';
@@ -24,11 +25,14 @@ type IOpts = {
 } & Pick<IConfigOpts, 'cache'>;
 
 export async function dev(opts: IOpts) {
-  // swc currently not support Top level await, should use esbuild in development env.
-  const enableMFSU =
-    opts.config.mfsu !== false && opts.config.srcTranspiler !== Transpiler.swc;
+  const enableMFSU = opts.config.mfsu !== false;
   let mfsu: MFSU | null = null;
   if (enableMFSU) {
+    if (opts.config.srcTranspiler === Transpiler.swc) {
+      logger.warn(
+        `Swc currently not supported for use with mfsu, recommended you use srcTranspiler: 'esbuild' in dev.`,
+      );
+    }
     mfsu = new MFSU({
       implementor: webpack as any,
       buildDepWithESBuild: opts.config.mfsu?.esbuild,

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -4,7 +4,7 @@ import webpack from '../compiled/webpack';
 import { getConfig, IOpts as IConfigOpts } from './config/config';
 import { MFSU_NAME } from './constants';
 import { createServer } from './server/server';
-import { Env, IConfig } from './types';
+import { Env, IConfig, Transpiler } from './types';
 
 type IOpts = {
   afterMiddlewares?: any[];
@@ -24,7 +24,9 @@ type IOpts = {
 } & Pick<IConfigOpts, 'cache'>;
 
 export async function dev(opts: IOpts) {
-  const enableMFSU = opts.config.mfsu !== false;
+  // swc currently not support Top level await, should use esbuild in development env.
+  const enableMFSU =
+    opts.config.mfsu !== false && opts.config.srcTranspiler !== Transpiler.swc;
   let mfsu: MFSU | null = null;
   if (enableMFSU) {
     mfsu = new MFSU({

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -79,6 +79,7 @@ export interface IConfig {
 export interface SwcOptions extends SwcConfig {
   sync?: boolean;
   parseMap?: boolean;
+  targets?: Record<string, any>;
 }
 
 export interface IEsbuildLoaderHandlerParams {

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -41,7 +41,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router": "6.1.1",
-    "react-router-dom": "6.1.1"
+    "react-router-dom": "6.1.1",
+    "regenerator-runtime": "0.13.9"
   },
   "devDependencies": {
     "@types/body-parser": "1.19.2",

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -1,4 +1,5 @@
 import { transform } from '@umijs/bundler-utils/compiled/babel/core';
+import { Transpiler } from '@umijs/bundler-webpack/dist/types';
 import { dirname } from 'path';
 import { IApi } from '../../types';
 
@@ -12,7 +13,10 @@ export default (api: IApi) => {
         });
       },
     },
-    enableBy: () => {
+    enableBy: ({ userConfig }) => {
+      if (userConfig.srcTranspiler === Transpiler.swc) {
+        return false;
+      }
       return process.env.BABEL_POLYFILL !== 'none';
     },
   });
@@ -26,7 +30,7 @@ export default (api: IApi) => {
     const { code } = transform(
       `
 ${coreJsImports}
-import 'regenerator-runtime/runtime';
+import '${require.resolve('regenerator-runtime/runtime')}';
 export {};
 `,
       {

--- a/packages/preset-umi/src/features/polyfill/swcPolyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/swcPolyfill.ts
@@ -1,0 +1,21 @@
+import { Transpiler } from '@umijs/bundler-webpack/dist/types';
+import { dirname } from 'path';
+import { IApi } from '../../types';
+
+export default (api: IApi) => {
+  api.describe({
+    enableBy: ({ userConfig }) => {
+      const isSwcTranspiler = userConfig.srcTranspiler === Transpiler.swc;
+      return isSwcTranspiler;
+    },
+  });
+
+  // support swc find polfyill
+  api.modifyConfig((memo) => {
+    memo.alias['regenerator-runtime'] = dirname(
+      require.resolve('regenerator-runtime/package'),
+    );
+    memo.alias['core-js'] = dirname(require.resolve('core-js/package'));
+    return memo;
+  });
+};

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -14,6 +14,7 @@ export default () => {
       require.resolve('./features/mock/mock'),
       require.resolve('./features/polyfill/polyfill'),
       require.resolve('./features/polyfill/publicPathPolyfill'),
+      require.resolve('./features/polyfill/swcPolyfill'),
       require.resolve('./features/tmpFiles/tmpFiles'),
       require.resolve('./features/transform/transform'),
       require.resolve('./features/lowImport/lowImport'),


### PR DESCRIPTION
这个 pr 做了几件事：

1. 支持 swc 按需取用 polyfill 

2. 改善了 swc 的配置

3. 在 swc 作为 transpiler 场景自动关闭 mfsu，因为他们不兼容

这将在基础 polyfill 大小上获取 80kb 左右的收益：

<img src='https://user-images.githubusercontent.com/59400654/151495012-b728096f-1d8b-45f9-944e-82d1a26e7ce2.png' width='70%' />

同时提升 x1.5 - x2 的编译速度 （无缓存测试，但 babel 场景默认 preset 导入了更多的 polyfill 会增加处理代码量）：

<img src='https://user-images.githubusercontent.com/59400654/151495245-094bafa4-c8e9-4738-8d16-78ef1d8f788a.png' width='50%' />

