### PR TITLE
fix(plugin-docs): Fixed build failed caused by no .svg module declaration

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -2,3 +2,8 @@ declare module '*.png' {
   const src: string
   export default src
 }
+
+declare module '*.svg' {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
修复了 plugin-docs 的 Hero 组件引入了 .svg 图示但没有 module declaration 造成的 tsc 编译失败

<img width="1728" alt="Screen Shot 2022-01-28 at 3 16 55 PM" src="https://user-images.githubusercontent.com/21105863/151504434-2cc9600e-18ca-43d5-814d-59ff14fb784d.png">

