### PR TITLE
feat(plugin-docs): Added <Features /> component for landing page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,41 @@
-import { Hero } from 'umi';
+import { Hero, Features, FeatureItem } from 'umi';
 
 <Hero 
   description="以路由为基础，同时支持配置式路由和约定式路由，配以生命周期完善的插件体系，覆盖从源码到构建产物的每个生命周期，支持各种功能扩展和业务需求。"
   buttons={[{label: "快速开始", href: "docs/tutorials/getting-started"}]} 
   githubRepo="umijs/umi"
 />
+
+<Features title="为什么选择 Umi" subtitle="Umi 透过以下几个特色，提供你快速且可靠的前端开发能力">
+  <FeatureItem 
+    title="可扩展" 
+    description="Umi 实现了完整的生命周期，并使其插件化，Umi 内部功能也全由插件完成。此外还支持插件和插件集，以满足功能和垂直域的分层需求。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/a1c647aa-a410-4024-8414-c9837709cb43/k7787itw_w126_h114.png"
+  />
+  <FeatureItem 
+    title="开箱即用" 
+    description="Umi 内置了路由、构建、部署、测试等，仅需一个依赖即可上手开发。并且还提供针对 React 的集成插件集，内涵丰富的功能，可满足日常 80% 的开发需求。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/b54b48c7-087a-4984-b150-bcecb40920de/k7787z07_w114_h120.png"
+  />
+  <FeatureItem 
+    title="企业级" 
+    description="经蚂蚁内部 3000+ 项目以及阿里、优酷、网易、飞猪、口碑等公司项目的验证，值得信赖。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/464cb990-6db8-4611-89af-7766e208b365/k77899wk_w108_h132.png"
+  />
+  <FeatureItem 
+    title="大量自研" 
+    description="包含微前端、组件打包、文档工具、请求库、hooks 库、数据流等，满足日常项目的周边需求。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/201bea40-cf9d-4be2-a1d8-55bec136faf2/k7788a8s_w102_h120.png"
+  />
+  <FeatureItem 
+    title="完备路由" 
+    description="同时支持配置式路由和约定式路由，同时保持功能的完备性，比如动态路由、嵌套路由、权限路由等等。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/67b771c5-4bdd-4384-80a4-978b85f91282/k7788ov2_w126_h126.png"
+    link="https://umijs.org/zh-CN/docs/routing"
+  />
+  <FeatureItem 
+    title="面向未来" 
+    description="在满足需求的同时，我们也不会停止对新技术的探索。比如 modern mode、webpack@5、自动化 external、bundler less 等等。"
+    icon="https://gw.alipayobjects.com/zos/basement_prod/d078a5a9-1cb3-4352-9f05-505c2e98bc95/k7788v4b_w102_h126.png"
+  />
+</Features>

--- a/packages/plugin-docs/client/theme-doc/components/FeatureItem.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/FeatureItem.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+interface Feature {
+  icon: string;
+  title: string;
+  description: string;
+  link?: string
+}
+
+/**
+ * Feature Item 组件是文档首页第二个 Feature 区块中的一个 Item，
+ * 从 docs/README.md 中使用 MDX 语法调用，必须被包含在 <Features /> 组件内
+ * */
+function FeatureItem(props: Feature) {
+  return <div
+    className="w-3/4 lg:w-1/2 shrink-0 flex flex-row items-center
+    snap-always snap-center justify-center">
+    <div
+      className="flex flex-col w-5/6 lg:w-3/4 px-4 lg:px-16 items-center
+      bg-white dark:bg-gray-800 py-16
+      border-gray-300 dark:border-gray-500 border
+      rounded-xl shadow-xl h-96 lg:h-auto dark:shadow-gray-700">
+      <img src={props.icon} className="w-8 h-8" alt="feature-icon" />
+      <p
+        className="text-3xl lg:text-5xl font-extrabold
+         mt-4 mb-8 text-gray-900 dark:text-gray-200">
+        {props.title}
+      </p>
+      <p
+        className="text-center text-gray-800 dark:text-gray-400">
+        {props.description}
+      </p>
+      {props.link && <a
+        href={props.link}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-8 link-with-underline">
+        深入了解
+      </a>}
+    </div>
+  </div>
+}
+
+export default FeatureItem;

--- a/packages/plugin-docs/client/theme-doc/components/Features.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Features.tsx
@@ -1,0 +1,41 @@
+import React, { PropsWithChildren, useEffect, useRef } from "react"
+
+/**
+ * Features 组件是文档首页第二个 Feature 区块的容器，
+ * 从 docs/README.md 中使用 MDX 语法调用，可在内部传入 <FeatureItem /> 组件
+ * */
+function Features(props: PropsWithChildren<{ title?: string, subtitle?: string }>) {
+
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    /** 组件加载完毕后，移动滑动条到某个 Feature Item 上，否则初始状态是歪的*/
+    if (ref) ref.current?.scrollTo(600, 0)
+  }, [ref])
+
+  return <div
+    className="w-screen py-36 features dark:features-dark min-h-screen">
+    {(props.title || props.subtitle) && <div className="mb-24 px-4">
+      {props.title && <p
+        className="text-4xl lg:text-5xl font-extrabold mb-4 text-center
+          text-gray-700 dark:text-gray-300">
+        {props.title}
+      </p>}
+      {props.subtitle && <p
+        className="text-lg lg:text-xl text-center
+          text-gray-500 dark:text-gray-400">
+        {props.subtitle}
+      </p>}
+    </div>}
+    <div
+      ref={ref}
+      className="w-full flex flex-row snap-x overflow-x-scroll
+       features pb-12 dark:features-dark">
+      <div className="w-1/2 shrink-0" />
+      {props.children}
+      <div className="w-1/2 shrink-0" />
+    </div>
+  </div>
+}
+
+export default Features

--- a/packages/plugin-docs/client/theme-doc/index.ts
+++ b/packages/plugin-docs/client/theme-doc/index.ts
@@ -2,4 +2,6 @@ import './tailwind.out.css';
 // Components
 export { default as Hero } from './components/Hero';
 export { default as Message } from './components/Message';
+export { default as Features } from './components/Features';
+export { default as FeatureItem } from './components/FeatureItem';
 export { default as Layout } from './Layout';

--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -87,6 +87,11 @@ article a {
   background-image: linear-gradient(transparent 60%, rgba(130, 199, 255, 0.28) 55%);
 }
 
+.link-with-underline {
+  @apply text-blue-600 mx-1 hover:text-blue-300 transition dark:text-blue-400;
+  background-image: linear-gradient(transparent 60%, rgba(130, 199, 255, 0.28) 55%);
+}
+
 /*article pre {*/
 /*  @apply pt-12;*/
 /*}*/
@@ -112,4 +117,29 @@ html {
 /** Anchor with offset for headings */
 h1, h2, h3, h4, h5, h6 {
   scroll-margin-top: 3em;
+}
+
+@layer components {
+
+  .features-dark {
+    @apply bg-gray-900;
+    background-image: radial-gradient(#2a2a2a 20%, transparent 20%);
+    background-size: 6px 6px;
+    width: 100%;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .features {
+    background-image: radial-gradient(#f8f8f5 20%, transparent 20%);
+    background-color: white;
+    background-size: 6px 6px;
+    width: 100%;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .features::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/packages/plugin-docs/src/index.ts
+++ b/packages/plugin-docs/src/index.ts
@@ -68,7 +68,7 @@ export default (api: IApi) => {
     api.writeTmpFile({
       path: 'index.ts',
       content: `
-export { Message, Hero } from '${require.resolve('../client/theme-doc')}';
+export { Message, Hero, Features, FeatureItem } from '${require.resolve('../client/theme-doc')}';
     `,
     });
 


### PR DESCRIPTION
在 `plugin-docs` 的 `theme-doc` 主题加入了 `<Features />` 和 `<FeatureItem />` 组件。

# 使用方式

```
// docs/README.md

<Features 
  title="为什么选择 Umi"
  subtitle="Umi 透过以下几个特色，提供你快速且可靠的前端开发能力"
>

  <FeatureItem 
    title="可扩展" 
    description="Umi 实现了完整的生命周期，并使其插件化，Umi 内部功能也全由插件完成。此外还支持插件和插件集，以满足功能和垂直域的分层需求。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/a1c647aa-a410-4024-8414-c9837709cb43/k7787itw_w126_h114.png"
  />

  <FeatureItem 
    title="开箱即用" 
    description="Umi 内置了路由、构建、部署、测试等，仅需一个依赖即可上手开发。并且还提供针对 React 的集成插件集，内涵丰富的功能，可满足日常 80% 的开发需求。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/b54b48c7-087a-4984-b150-bcecb40920de/k7787z07_w114_h120.png"
  />

  <FeatureItem 
    title="企业级" 
    description="经蚂蚁内部 3000+ 项目以及阿里、优酷、网易、飞猪、口碑等公司项目的验证，值得信赖。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/464cb990-6db8-4611-89af-7766e208b365/k77899wk_w108_h132.png"
  />

  <FeatureItem 
    title="大量自研" 
    description="包含微前端、组件打包、文档工具、请求库、hooks 库、数据流等，满足日常项目的周边需求。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/201bea40-cf9d-4be2-a1d8-55bec136faf2/k7788a8s_w102_h120.png"
  />

  <FeatureItem 
    title="完备路由" 
    description="同时支持配置式路由和约定式路由，同时保持功能的完备性，比如动态路由、嵌套路由、权限路由等等。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/67b771c5-4bdd-4384-80a4-978b85f91282/k7788ov2_w126_h126.png"
    link="https://umijs.org/zh-CN/docs/routing"
  />

  <FeatureItem 
    title="面向未来" 
    description="在满足需求的同时，我们也不会停止对新技术的探索。比如 modern mode、webpack@5、自动化 external、bundler less 等等。"
    icon="https://gw.alipayobjects.com/zos/basement_prod/d078a5a9-1cb3-4352-9f05-505c2e98bc95/k7788v4b_w102_h126.png"
  />

</Features>
```

Features 组件提供两个可选的 props: `title` 和 `subtitle`，会被渲染在 Features 区块的上方。

FeatureItem 组件提供 3 个必要的 props: `icon`, `title`, `description` 及一个可选的 prop: `link`。

# 效果演示

Features 组件会将内部的 FeatureItem 渲染到一个可滚动的横向列表中，每个 FeatureItem 以一个卡片的形式呈现。

<img width="1223" alt="Screen Shot 2022-02-07 at 5 21 49 PM" src="https://user-images.githubusercontent.com/21105863/152760339-b812a49f-f968-4f9c-a7d8-00b7f098d08b.png">

暗黑模式

<img width="1223" alt="Screen Shot 2022-02-07 at 5 24 03 PM" src="https://user-images.githubusercontent.com/21105863/152760673-f653672c-b343-4389-8d4f-0dfb78779e3b.png">

带有 link 的 FeatureItem

<img width="1087" alt="Screen Shot 2022-02-07 at 5 25 35 PM" src="https://user-images.githubusercontent.com/21105863/152760951-9ee3496e-b911-475e-a3fa-08e70450297c.png">

小屏自适应

<img width="405" alt="Screen Shot 2022-02-07 at 5 27 01 PM" src="https://user-images.githubusercontent.com/21105863/152761133-f07c941d-8f37-48fc-8147-382c77dd40d7.png">

