### PR TITLE
fix(swc): auto css plugin visit js file error

### DIFF
--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -116,7 +116,6 @@ export async function addJavaScriptRules(opts: IOpts) {
           ].filter(Boolean),
         });
     } else if (srcTranspiler === Transpiler.swc) {
-      // TODO: support javascript
       rule
         .use('swc-loader')
         .loader(require.resolve('../loader/swc'))

--- a/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
+++ b/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
@@ -1,10 +1,17 @@
-import { ImportDeclaration, TsType, VariableDeclaration } from '@swc/core';
+import type { ImportDeclaration, ModuleItem, TsType } from '@swc/core';
 import Visitor from '@swc/core/Visitor';
 import { isStyleFile } from '@umijs/utils';
 
 class AutoCSSModule extends Visitor {
   visitTsType(expression: TsType) {
     return expression;
+  }
+
+  visitModuleItem(n: ModuleItem) {
+    if (n.type === 'ImportDeclaration') {
+      return this.visitImportDeclaration(n);
+    }
+    return n;
   }
 
   visitImportDeclaration(expression: ImportDeclaration): ImportDeclaration {
@@ -20,28 +27,6 @@ class AutoCSSModule extends Visitor {
         },
       };
     }
-    return expression;
-  }
-
-  visitVariableDeclaration(
-    expression: VariableDeclaration,
-  ): VariableDeclaration {
-    const { declarations } = expression;
-    if (
-      declarations.length &&
-      declarations[0].init &&
-      declarations[0].init.type === 'AwaitExpression' &&
-      declarations[0].init.argument.type === 'CallExpression' &&
-      declarations[0].init.argument.arguments.length &&
-      declarations[0].init.argument.arguments[0].expression.type ===
-        'StringLiteral' &&
-      isStyleFile({
-        filename: declarations[0].init.argument.arguments[0].expression.value,
-      })
-    ) {
-      declarations[0].init.argument.arguments[0].expression.value = `${declarations[0].init.argument.arguments[0].expression.value}?modules`;
-    }
-
     return expression;
   }
 }

--- a/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
+++ b/packages/bundler-webpack/src/swcPlugins/autoCSSModules.ts
@@ -7,6 +7,11 @@ class AutoCSSModule extends Visitor {
     return expression;
   }
 
+  /**
+   * call path:
+   *   visitProgram -> visitModule -> visitModuleItems -> visitModuleItem -> visitImportDeclaration
+   * @see https://github.com/swc-project/swc/blob/main/node-swc/src/Visitor.ts#L189
+   */
   visitModuleItem(n: ModuleItem) {
     if (n.type === 'ImportDeclaration') {
       return this.visitImportDeclaration(n);

--- a/packages/bundler-webpack/src/swcPlugins/autoCssModules.test.ts
+++ b/packages/bundler-webpack/src/swcPlugins/autoCssModules.test.ts
@@ -53,24 +53,6 @@ test('css modules', () => {
   );
 });
 
-// test('css with top level await', () => {
-//   expect(
-//     doTransform({ code: `const styles = await import('a.css');` }),
-//   ).toEqual(`const styles = await import('a.css?modules');`);
-//   expect(doTransform({ code: `await import('a.css');` })).toEqual(
-//     `await import('a.css');`,
-//   );
-// });
-
-// test('none css with top level await', () => {
-//   expect(doTransform({ code: `const styles = await import('a');` })).toEqual(
-//     `const styles = await import('a');`,
-//   );
-//   expect(doTransform({ code: `await import('a');` })).toEqual(
-//     `await import('a');`,
-//   );
-// });
-
 test('no css modules', () => {
   expect(doTransform({ code: `import 'a.css';` })).toEqual(`import 'a.css';`);
 });


### PR DESCRIPTION
##### 问题

解决在 `examples` 之外，单独使用 `umi` 时（即正常的开发者使用场景），使用 `swc` 作为 transpiler ，auto css 插件 visit 遍历访问语法树会报错的问题。

#### 解决

1. 限制收窄 visit 的访问场景仅限于需要处理的部分，即 import declare （ eg. `import styles from './index.less'` ）

2. 不考虑 `await import('./index.less')` 的场景，没有必要
