### PR TITLE
chore(swc): remove swc auto polyfill

### DIFF
--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -121,7 +121,6 @@ export async function addJavaScriptRules(opts: IOpts) {
         .loader(require.resolve('../loader/swc'))
         .options({
           plugin: (m: Program) => new AutoCSSModule().visitProgram(m),
-          targets: userConfig.targets,
         });
     } else if (srcTranspiler === Transpiler.esbuild) {
       rule

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -79,7 +79,6 @@ export interface IConfig {
 export interface SwcOptions extends SwcConfig {
   sync?: boolean;
   parseMap?: boolean;
-  targets?: Record<string, any>;
 }
 
 export interface IEsbuildLoaderHandlerParams {

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -1,5 +1,4 @@
 import { transform } from '@umijs/bundler-utils/compiled/babel/core';
-import { Transpiler } from '@umijs/bundler-webpack/dist/types';
 import { getCorejsVersion } from '@umijs/utils';
 import { dirname, join } from 'path';
 import { IApi } from '../../types';
@@ -14,10 +13,7 @@ export default (api: IApi) => {
         });
       },
     },
-    enableBy: ({ userConfig }) => {
-      if (userConfig.srcTranspiler === Transpiler.swc) {
-        return false;
-      }
+    enableBy: () => {
       return process.env.BABEL_POLYFILL !== 'none';
     },
   });

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -14,7 +14,6 @@ export default () => {
       require.resolve('./features/mock/mock'),
       require.resolve('./features/polyfill/polyfill'),
       require.resolve('./features/polyfill/publicPathPolyfill'),
-      require.resolve('./features/polyfill/swcPolyfill'),
       require.resolve('./features/tmpFiles/tmpFiles'),
       require.resolve('./features/transform/transform'),
       require.resolve('./features/lowImport/lowImport'),


### PR DESCRIPTION
#### 做法

取消了 swc 的自动 polyfill 机制，改为一致使用 entry 策略生成的 polyfill 导入。

#### 原因

1. **es2022 不支持**：受 #335 启发，尝试未正式发布的 es2022 特性（如 `array.at`），发现无论使用哪种 swc 提供的 polyfill 策略（`usage` / `entry`），都无法提供 es2022 的 polyfill （其中 `entry` 策略最多提供至 es2021 ）

2. **polyfill 查询列表已过时**：swc 的策略是自己维护了一份 `core-js-compat` 的 `modules-by-versions.json` 列表（已过时），无法即时同步上游 `core-js` 的最新 polyfill 变动

3. **未积极维护**：swc 长时间未积极维护 polyfill 功能模块

Refer:

https://github.com/swc-project/swc/issues/2607
https://github.com/swc-project/swc/issues/1604


综上情况，目前不应使用任何 swc 的 polyfill 提供策略，一致使用 babel 生成解 polyfill 问题。

#### 其他

使用 swc 的 `env.include` 也可解该问题，其实现与当前 babel 生成 polyfill 大致相同，可见于我的 [swc polyfill 解法](https://blog.csdn.net/qq_21567385/article/details/122844920) 一文。

