### PR TITLE
[WIP] feat: support window

### DIFF
--- a/examples/boilerplate/.umirc.ts
+++ b/examples/boilerplate/.umirc.ts
@@ -18,9 +18,7 @@ export default {
   chainWebpack(memo: any) {
     memo;
   },
-  mfsu: {
-    esbuild: true,
-  },
+  mfsu: {},
   // fastRefresh: false,
   // favicon: 'https://sivers.com/favicon.ico',
   headScripts: [`console.log('head script')`],

--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -1,4 +1,4 @@
-import { pkgUp } from '@umijs/utils';
+import { pkgUp, winPath } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
@@ -38,12 +38,12 @@ export class Dep {
     cwd: string;
     mfsu: MFSU;
   }) {
-    this.file = opts.file;
+    this.file = winPath(opts.file);
     this.version = opts.version;
-    this.cwd = opts.cwd;
+    this.cwd = winPath(opts.cwd);
     this.shortFile = this.file;
     this.normalizedFile = this.shortFile.replace(/\//g, '_').replace(/:/g, '_');
-    this.filePath = `${MF_VA_PREFIX}${this.normalizedFile}.js`;
+    this.filePath = winPath(`${MF_VA_PREFIX}${this.normalizedFile}.js`);
     this.mfsu = opts.mfsu;
   }
 

--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -1,4 +1,4 @@
-import { fsExtra, lodash, logger } from '@umijs/utils';
+import { fsExtra, lodash, logger, winPath } from '@umijs/utils';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { MFSU } from './mfsu';
@@ -56,13 +56,15 @@ export class DepInfo {
     logger.info('MFSU write cache');
     writeFileSync(
       this.cacheFilePath,
-      JSON.stringify(
-        {
-          cacheDependency: this.cacheDependency,
-          moduleGraph: this.moduleGraph.toJSON(),
-        },
-        null,
-        2,
+      winPath(
+        JSON.stringify(
+          {
+            cacheDependency: this.cacheDependency,
+            moduleGraph: this.moduleGraph.toJSON(),
+          },
+          null,
+          2,
+        ),
       ),
       'utf-8',
     );

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -1,5 +1,5 @@
 import { parseModule } from '@umijs/bundler-utils';
-import { lodash, logger, tryPaths } from '@umijs/utils';
+import { lodash, logger, tryPaths, winPath } from '@umijs/utils';
 import assert from 'assert';
 import type { NextFunction, Request, Response } from 'express';
 import { readFileSync, statSync } from 'fs';
@@ -56,10 +56,10 @@ export class MFSU {
     this.opts = opts;
     this.opts.mfName = this.opts.mfName || DEFAULT_MF_NAME;
     this.opts.tmpBase =
-      this.opts.tmpBase || join(process.cwd(), DEFAULT_TMP_DIR_NAME);
+      this.opts.tmpBase || winPath(join(process.cwd(), DEFAULT_TMP_DIR_NAME));
     this.opts.mode = this.opts.mode || Mode.development;
     this.opts.getCacheDependency = this.opts.getCacheDependency || (() => ({}));
-    this.opts.cwd = this.opts.cwd || process.cwd();
+    this.opts.cwd = winPath(this.opts.cwd || process.cwd());
     this.depInfo = new DepInfo({ mfsu: this });
     this.depBuilder = new DepBuilder({ mfsu: this });
     this.depInfo.loadCache();
@@ -68,7 +68,7 @@ export class MFSU {
   // swc don't support top-level await
   // ref: https://github.com/vercel/next.js/issues/31054
   asyncImport(content: string) {
-    return `await import('${content}');`;
+    return `await import('${winPath(content)}');`;
     // return `(async () => await import('${content}'))();`;
   }
 

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -1,6 +1,6 @@
 import { transform } from '@umijs/bundler-utils/compiled/babel/core';
 import { Transpiler } from '@umijs/bundler-webpack/dist/types';
-import { getCorejsVersion } from '@umijs/utils';
+import { getCorejsVersion, winPath } from '@umijs/utils';
 import { dirname, join } from 'path';
 import { IApi } from '../../types';
 
@@ -31,7 +31,7 @@ export default (api: IApi) => {
     const { code } = transform(
       `
 ${coreJsImports}
-import '${require.resolve('regenerator-runtime/runtime')}';
+import '${winPath(require.resolve('regenerator-runtime/runtime'))}';
 export {};
 `,
       {

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -31,7 +31,7 @@ export default (api: IApi) => {
       tplPath: join(TEMPLATES_DIR, 'umi.tpl'),
       context: {
         mountElementId: api.config.mountElementId,
-        rendererPath,
+        rendererPath: winPath(rendererPath),
         entryCode: (
           await api.applyPlugins({
             key: 'addEntryCode',
@@ -164,7 +164,7 @@ export default function EmptyRoute() {
       path: 'core/history.ts',
       tplPath: join(TEMPLATES_DIR, 'history.tpl'),
       context: {
-        rendererPath,
+        rendererPath: winPath(rendererPath),
       },
     });
   });
@@ -182,8 +182,8 @@ export default function EmptyRoute() {
       const exports = [];
       // @umijs/renderer-react
       exports.push('// @umijs/renderer-react');
-      const rendererReactPath = dirname(
-        require.resolve('@umijs/renderer-react/package.json'),
+      const rendererReactPath = winPath(
+        dirname(require.resolve('@umijs/renderer-react/package.json')),
       );
       exports.push(
         `export { ${(
@@ -195,7 +195,7 @@ export default function EmptyRoute() {
       // umi/client/client/plugin
       exports.push('// umi/client/client/plugin');
       const umiDir = process.env.UMI_DIR!;
-      const umiPluginPath = join(umiDir, 'client/client/plugin.js');
+      const umiPluginPath = winPath(join(umiDir, 'client/client/plugin.js'));
       exports.push(
         `export { ${(
           await getExports({


### PR DESCRIPTION
umi@4 的 window 电脑兼容

调试用例 examples/boilerplate
- [x] 不开mfsu umi dev
- [ ] 开启mfsu 
- [ ] 开启 mfsu 的 esbuild 模式

当前进度：
cd examples/boilerplate && pnpm dev

![image](https://user-images.githubusercontent.com/11746742/153366611-fd4f2cbf-7d1f-433e-a9f8-86e0449553f2.png)


可尝试下一步方案：
https://github.com/umijs/umi-next/blob/62c67d0bf3ed31128e1490b31df3bd840695a0fc/packages/preset-umi/src/registerMethods.ts#L110-L109
这个问题需要在这里加一段处理，如果 process.platform === 'win32'，处理所有 import from 的内容，如果是绝对路径，用 winPath 处理下。

也可能是
https://github.com/umijs/umi-next/blob/ad89836c617024b4fbb6fab21734f81b218ae395/packages/preset-umi/src/utils/transformIEAR.ts#L16
这个绝对路径的判断好像不支持 win？

