### PR TITLE
ci: upgrade cache actions version and use pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node${{ matrix.node-version }}-
       - name: Install pnpm
-        run: npm i pnpm -g
-      - name: install
-        run: pnpm install
+        uses: pnpm/action-setup@v2.1.0
+        with:
+          version: latest
+          run_install: true
       - run: pnpm build
       - run: pnpm tsc --noEmit
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,13 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: 'https://registry.npmjs.org/'
-      - name: Cache .pnpm-store
-        id: cache
-        uses: actions/cache@v1
+      - name: Cache pnpm modules
+        uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-
       - name: Install pnpm
         run: npm i pnpm -g
       - name: install


### PR DESCRIPTION

这两次 commit 的 ci 中， **macos** 的 post cache 都超时挂了：

https://github.com/umijs/umi-next/runs/5143960840?check_suite_focus=true
https://github.com/umijs/umi-next/runs/5141916853?check_suite_focus=true

用 pnpm 官方给的示范（ [pnpm/action-setup](https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time) ），升级下版本来解决问题
