### PR TITLE
feat(bundler-webpack): dev missing babelPreset

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -13,6 +13,7 @@ type IOpts = {
   onDevCompileDone?: Function;
   port?: number;
   host?: string;
+  babelPreset?: any;
   chainWebpack?: Function;
   modifyWebpackConfig?: Function;
   beforeBabelPlugins?: any[];
@@ -55,6 +56,7 @@ export async function dev(opts: IOpts) {
     env: Env.development,
     entry: opts.entry,
     userConfig: opts.config,
+    babelPreset: opts.babelPreset,
     extraBabelPlugins: [
       ...(opts.beforeBabelPlugins || []),
       ...(mfsu?.getBabelPlugins() || []),

--- a/packages/bundler-webpack/src/requireHook.ts
+++ b/packages/bundler-webpack/src/requireHook.ts
@@ -15,7 +15,7 @@ const hookPropertyMap = new Map([
 ]);
 
 deepImports.forEach((item: string) => {
-  const name = item.split('/').unshift();
+  const name = item.split('/').pop();
   hookPropertyMap.set(item, `@umijs/bundler-webpack/compiled/webpack/${name}`);
   hookPropertyMap.set(
     `${item}.js`,


### PR DESCRIPTION
1. 修复 requireHook.ts webpack deepImports name 获取有问题导致三方插件使用有问题
2. dev 模式未传 babelPreset 导致无法覆盖默认的 babelPreset