### PR TITLE
fix(plugin-docs): Added HTML title

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import React, { Fragment, useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import Announcement from './components/Announcement';
 import { ThemeContext } from './context';
 import Head from './Head';
@@ -52,7 +53,12 @@ export default (props: any) => {
         <div className="g-glossy-firefox" id="firefox-head-bg" />
 
         {window.location.pathname === '/' ? (
-          <div id="article-body">{props.children}</div>
+          <div id="article-body">
+            <Helmet>
+              <title>UmiJS - 插件化的企业级前端应用框架</title>
+            </Helmet>
+            {props.children}
+          </div>
         ) : (
           <Fragment>
             <div

--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -29,6 +29,8 @@ export default (props: any) => {
     };
   }, []);
 
+  const { title, description } = props.themeConfig;
+
   return (
     <ThemeContext.Provider
       value={{
@@ -55,7 +57,10 @@ export default (props: any) => {
         {window.location.pathname === '/' ? (
           <div id="article-body">
             <Helmet>
-              <title>UmiJS - 插件化的企业级前端应用框架</title>
+              <title>
+                {title}
+                {description ? ` - ${description}` : ''}
+              </title>
             </Helmet>
             {props.children}
           </div>

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -11,7 +11,7 @@ function getLinkFromTitle(title: string) {
 }
 
 export default () => {
-  const { location, appData } = useThemeContext()!;
+  const { location, appData, themeConfig } = useThemeContext()!;
   const lang = useLanguage();
   const route =
     appData.routes[
@@ -33,7 +33,9 @@ export default () => {
       border-gray-100 p-8 rounded-xl z-20"
     >
       <Helmet>
-        <title>{route.titles[0].title} | UmiJS</title>
+        <title>
+          {route.titles[0].title} | {themeConfig.title}
+        </title>
       </Helmet>
       <p className="text-lg font-extrabold dark:text-white">
         {route.titles[0].title}

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
 
@@ -31,6 +32,9 @@ export default () => {
       className="w-full lg:m-12 mb-12 border
       border-gray-100 p-8 rounded-xl z-20"
     >
+      <Helmet>
+        <title>{route.titles[0].title} | UmiJS</title>
+      </Helmet>
       <p className="text-lg font-extrabold dark:text-white">
         {route.titles[0].title}
       </p>

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -5,6 +5,7 @@ interface IContext {
   components: any;
   themeConfig: {
     title: string;
+    description?: string;
     github: string;
     // 键盘搜索的快捷键，参考 https://github.com/madrobby/keymaster
     searchHotKey?: string | { macos: string; windows: string };

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -23,11 +23,13 @@
     "dev": "pnpm build -- --watch"
   },
   "dependencies": {
-    "keymaster": "1.6.2"
+    "keymaster": "1.6.2",
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
     "@mdx-js/mdx": "2.0.0",
     "@types/keymaster": "^1.6.30",
+    "@types/react-helmet": "^6.1.5",
     "classnames": "^2.3.1",
     "rehype-slug": "5.0.1",
     "tailwindcss": "^3.0.22",

--- a/theme.config.ts
+++ b/theme.config.ts
@@ -3,6 +3,7 @@ import UmiLogo from './packages/plugin-docs/client/theme-doc/icons/umi.png';
 
 export default {
   title: 'UmiJS',
+  description: '插件化的企业级前端应用框架',
   logo: UmiLogo,
   github: 'https://github.com/umijs/umi',
   i18n: [


### PR DESCRIPTION
帮 plugin-docs 的 theme-doc 加入了 HTML title。

### 首页

<img width="819" alt="Screen Shot 2022-02-16 at 4 57 01 PM" src="https://user-images.githubusercontent.com/21105863/154230352-bb9df303-a479-4352-8283-18d5615a4231.png">

### 文档

<img width="819" alt="Screen Shot 2022-02-16 at 4 57 14 PM" src="https://user-images.githubusercontent.com/21105863/154230367-d9ebef84-6989-4f4c-b020-d4ff2862d431.png">

