### PR TITLE
feat(webpack): auto inject `umi` chunk assets

### DIFF
--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -111,37 +111,26 @@ umi build --clean
         clean: api.args.clean,
       };
 
-      let stats: any;
       if (api.args.vite) {
-        stats = await bundlerVite.build(opts);
+        await bundlerVite.build(opts);
       } else {
-        stats = await bundlerWebpack.build(opts);
-      }
-
-      function getAssetsMap(stats: any) {
-        if (api.args.vite) {
-          // TODO: FIXME: vite
-          return { 'umi.js': 'umi.js', 'umi.css': 'umi.css' };
-        }
-
-        let ret: Record<string, string> = {};
-        for (const asset of stats.toJson().entrypoints['umi'].assets) {
-          if (/^umi\..+?\.js$/.test(asset.name)) {
-            ret['umi.js'] = asset.name;
-          }
-          if (/^umi\..+?\.css$/.test(asset.name)) {
-            ret['umi.css'] = asset.name;
-          }
-        }
-        return ret;
+        await bundlerWebpack.build(opts);
       }
 
       function getAsset(name: string) {
-        return assetsMap[name] ? [`/${assetsMap[name]}`] : [];
+        // TODO: FIXME: vite
+        if (api.args.vite) {
+          const assetsMap: Record<string, string[]> = {
+            'umi.js': ['umi.js'],
+            'umi.css': ['umi.css'],
+          };
+          return assetsMap[name];
+        }
+        // webpack: auto inject
+        return [];
       }
 
       // generate html
-      const assetsMap = getAssetsMap(stats);
       const { vite } = api.args;
       const markupArgs = await getMarkupArgs({ api });
       // @ts-ignore

--- a/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
@@ -26,8 +26,8 @@ export function createRouteMiddleware(opts: { api: IApi }): RequestHandler {
     // @ts-ignore
     const requestHandler = await createRequestHandler({
       ...markupArgs,
-      styles: ['/umi.css'].concat(markupArgs.styles),
-      scripts: (vite ? viteScripts : ['/umi.js']).concat(markupArgs.scripts!),
+      styles: [].concat(markupArgs.styles),
+      scripts: (vite ? viteScripts : []).concat(markupArgs.scripts!),
       esmScript: vite,
     });
     requestHandler(req, res, next);

--- a/packages/preset-umi/src/features/assets/umi.ts
+++ b/packages/preset-umi/src/features/assets/umi.ts
@@ -1,0 +1,64 @@
+import type { Compiler } from '@umijs/bundler-webpack/compiled/webpack';
+import type { IApi } from '../../types';
+
+interface IAddUmiAssetsPluginOpts {
+  addAssets: (opts: { js?: string[]; css?: string[] }) => void;
+}
+
+const UMI_ASSETS_REG = {
+  js: /^umi(\..+)?\.js$/,
+  css: /^umi(\..+)?\.css$/,
+};
+
+const PLUGIN_NAME = 'add-umi-assets-plugin';
+class AddUmiAssetsPlugin {
+  isJsAdded = false;
+  isCssAdded = false;
+  addAssets;
+
+  constructor(options: IAddUmiAssetsPluginOpts) {
+    this.addAssets = options.addAssets;
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.done.tap(PLUGIN_NAME, (compilation) => {
+      if (this.isCssAdded && this.isJsAdded) return;
+      const assets = compilation.toJson().entrypoints?.['umi'].assets || [];
+      for (let asset of assets) {
+        const name = asset.name;
+        if (!name.startsWith('umi')) return;
+        if (!this.isJsAdded && UMI_ASSETS_REG.js.test(name)) {
+          this.isJsAdded = true;
+          this.addAssets({ js: [`/${name}`] });
+        }
+        if (!this.isCssAdded && UMI_ASSETS_REG.css.test(name)) {
+          this.isCssAdded = true;
+          this.addAssets({ css: [`/${name}`] });
+        }
+      }
+    });
+  }
+}
+
+export default (api: IApi) => {
+  api.chainWebpack((memo) => {
+    memo.plugin(PLUGIN_NAME).use(AddUmiAssetsPlugin, [
+      {
+        addAssets: ({ js = [], css = [] }) => {
+          if (css.length) {
+            api.addHTMLStyles({
+              fn: () => css,
+              stage: Number.NEGATIVE_INFINITY,
+            });
+          }
+          if (js.length) {
+            api.addHTMLScripts({
+              fn: () => js,
+              stage: Number.NEGATIVE_INFINITY,
+            });
+          }
+        },
+      },
+    ]);
+  });
+};

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -18,6 +18,7 @@ export default () => {
       require.resolve('./features/transform/transform'),
       require.resolve('./features/lowImport/lowImport'),
       require.resolve('./features/vite/vite'),
+      require.resolve('./features/assets/umi'),
 
       // commands
       require.resolve('./commands/build'),


### PR DESCRIPTION
#### 现状

先梳理一下 webpack 构建 `umi` 中间层代码 chunk 部分带来的 `umi.css` (或 `umi.*.css`) 。

他们注入 html 中的必要性如下：

**dev**

| |`umi.js`|`umi.css`|
|:-:|:-:|:-:|
|mfsu|✓| 无 (自动注入 `${srcDirName}_umi_umi_ts.chunk.ss`)| 
|no mfsu|✓|✓|

**build**

| |`umi.js`|`umi.css`|
|:-:|:-:|:-:|
|no mfsu|✓| ✓| 

如果在需要注入的时候不插入 html，应用会挂。

如果在不需要注入的时候插入，控制台会报错。

#### 说明

是否考虑一种 webpack 插件自动注入的形式来完成任意环境的 umi assets 插入行为。


