### PR TITLE
chore(env): ensure pnpm and node min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "umi": "workspace:*",
     "zx": "^4.3.0"
   },
-  "packageManager": "pnpm"
+  "engines": {
+    "node": ">=16",
+    "pnpm": ">=6.20.0"
+  },
+  "packageManager": "pnpm@6.20.0"
 }


### PR DESCRIPTION

1. **`packageManager` 标准化**：该字段的标准格式是 `name@version` ，可以看到 vscode 默认有虚线提示，且单独使用 `name` 是不被 `turborepo` 等社区工具识别的。

2. **限制开发时本地 `pnpm` 最小版本**：为了解 `peerDependencies` 和开发环境多实例寻址问题，以后可能需要 `dependenciesMeta` 来解，其要求的最小版本要 >=6.20 （[详见这里](https://pnpm.io/package_json#dependenciesmeta)），这里向后兼容

3. **限制开发时本地 node 最小版本**

