### PR TITLE
fix(build): identify umi output assets reg match

### DIFF
--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -129,7 +129,7 @@ umi build --clean
           if (/^umi(\..+)?\.js$/.test(asset.name)) {
             ret['umi.js'] = asset.name;
           }
-          if (/^umi(\..+)+?\.css$/.test(asset.name)) {
+          if (/^umi(\..+)?\.css$/.test(asset.name)) {
             ret['umi.css'] = asset.name;
           }
         }

--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -126,10 +126,10 @@ umi build --clean
 
         let ret: Record<string, string> = {};
         for (const asset of stats.toJson().entrypoints['umi'].assets) {
-          if (/^umi\..+?\.js$/.test(asset.name)) {
+          if (/^umi(\..+)?\.js$/.test(asset.name)) {
             ret['umi.js'] = asset.name;
           }
-          if (/^umi\..+?\.css$/.test(asset.name)) {
+          if (/^umi(\..+)+?\.css$/.test(asset.name)) {
             ret['umi.css'] = asset.name;
           }
         }


### PR DESCRIPTION

产物对 `umi` 的正则识别有问题，需要兼容 `umi.js` 和 `umi.*.js` 格式。

