### PR TITLE
dep: update @umijs/plugins to 4.0.0-rc.2

### DIFF
--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -5,7 +5,7 @@
     "start": "npm run dev"
   },
   "dependencies": {
-    "@umijs/plugins": "4.0.0-beta.16",
+    "@umijs/plugins": "4.0.0-rc.2",
     "tailwindcss": "^3.0.23",
     "umi": "4.0.0-rc.2"
   }


### PR DESCRIPTION
将 `@umijs/plugins` 的版本升级到 `4.0.0-rc.2`，解决 example 启动报错。