### PR TITLE
fix(mfsu): es module interop exports

### DIFF
--- a/packages/mfsu/src/depBuilder/getESBuildEntry.ts
+++ b/packages/mfsu/src/depBuilder/getESBuildEntry.ts
@@ -1,6 +1,21 @@
 import { MF_VA_PREFIX } from '../constants';
 import { Dep } from '../dep/dep';
 
+// from typescript `esModuleInterop`
+const ES_INTEROP_FUNC = `__exportStar`;
+const ES_INTEROP_HELPER = `
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+}));
+var ${ES_INTEROP_FUNC} = (this && this.__exportStar) || function(m, exports) {
+  for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+`;
+
 export function getESBuildEntry(opts: { deps: Dep[] }) {
   return `
 (function() {
@@ -265,6 +280,7 @@ export function getESBuildEntry(opts: { deps: Dep[] }) {
 var __webpack_exports__ = {};
 (function() {
   var exports = __webpack_exports__;
+${ES_INTEROP_HELPER}
   var moduleMap = {
 ${opts.deps.map(getDepModuleStr).join(',\n')}
   };
@@ -303,6 +319,7 @@ function getDepModuleStr(dep: Dep) {
 "./${dep.file}": function() {
   return new Promise(resolve => {
     import('./${MF_VA_PREFIX}${dep.normalizedFile}.js').then(module => {
+      module.default && ${ES_INTEROP_FUNC}(module, module.default);
       resolve(() => module.default || module);
     });
   })


### PR DESCRIPTION
#### 问题

当包的默认导出和具名导出不一致时可能发生获取不到的问题。

例子：使用 `styled-components` ：

```ts
// 可以具名导出一些东西
import { StyleSheetManager } from 'styled-components'

// 可以默认导入
import styled from 'styled-components'

// 可以调方法
const Wrapper = styled.div`
  color: red;
`

// 本身又是一个函数
const SomeDiv = styled('div')`
  color: orange;
`;

export default function HomePage() {
  return (
    <StyleSheetManager>
      <Wrapper>111</Wrapper>
      <SomeDiv>222</SomeDiv>
    </StyleSheetManager>
  );
}
```

可以理解为 `module.default` 是 `styled` ，虽然他本身又是函数又有挂一些属性方法

但是 `StyleSheetManager` 其实是不在 `styled` 上的，就会从 `module.default` 上拿不到。

#### 解法

这里 `module` 是一定有的。

一种解法是用 typescript 生成的代码里的 es 模块互操作的 helper 做法，即将 `module` 上的方法绑到 `module.default` 上，当然要考虑：

1. 没有 `module.default` 就不绑了，默认给 `module`

2. `module` 上的 `default` 不能绑给 `module.default`

3. `module.default` 上有的和 `module` 重名方法，不能把他从 `module[key]` 绑到 `module.default[key]`

#### 结果

解了这个问题，但是在我的 intel 电脑上有本地开发有多实例问题，还要加 `dependenciesMeta` 才跑得起来：

```js
// package.json

  "dependenciesMeta": {
    "umi": {
      "injected": true
    }
  }
```

在 m1 上没问题。

**或许有更好的解法？**
