### PR TITLE
feat(css-minify): support use `@parcel/css` minify css output

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -28,6 +28,7 @@
     "generate:webpackPackages": "zx ./scripts/generateWebpackPackages.mjs"
   },
   "dependencies": {
+    "@parcel/css": "1.3.2",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "@svgr/core": "6.2.1",
     "@svgr/plugin-jsx": "^6.2.1",

--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -3,7 +3,7 @@ import CSSMinimizerWebpackPlugin from '@umijs/bundler-webpack/compiled/css-minim
 import TerserPlugin from '../../compiled/terser-webpack-plugin';
 import Config from '../../compiled/webpack-5-chain';
 import ESBuildCSSMinifyPlugin from '../plugins/ESBuildCSSMinifyPlugin';
-import { ParcelCssMinifyPlugin } from '../plugins/ParcelCssMinifyPlugin';
+import { ParcelCSSMinifyPlugin } from '../plugins/ParcelCSSMinifyPlugin';
 import { CSSMinifier, Env, IConfig, JSMinifier } from '../types';
 
 interface IOpts {
@@ -63,10 +63,10 @@ export async function addCompressPlugin(opts: IOpts) {
           parallel: true,
         },
       ]);
-  } else if (cssMinifier === CSSMinifier.parcelCss) {
+  } else if (cssMinifier === CSSMinifier.parcelCSS) {
     config.optimization
       .minimizer(`css-${cssMinifier}`)
-      .use(ParcelCssMinifyPlugin);
+      .use(ParcelCSSMinifyPlugin);
   } else if (cssMinifier !== CSSMinifier.none) {
     throw new Error(`Unsupported cssMinifier ${userConfig.cssMinifier}.`);
   }

--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -3,6 +3,7 @@ import CSSMinimizerWebpackPlugin from '@umijs/bundler-webpack/compiled/css-minim
 import TerserPlugin from '../../compiled/terser-webpack-plugin';
 import Config from '../../compiled/webpack-5-chain';
 import ESBuildCSSMinifyPlugin from '../plugins/ESBuildCSSMinifyPlugin';
+import { ParcelCssMinifyPlugin } from '../plugins/ParcelCssMinifyPlugin';
 import { CSSMinifier, Env, IConfig, JSMinifier } from '../types';
 
 interface IOpts {
@@ -62,6 +63,10 @@ export async function addCompressPlugin(opts: IOpts) {
           parallel: true,
         },
       ]);
+  } else if (cssMinifier === CSSMinifier.parcelCss) {
+    config.optimization
+      .minimizer(`css-${cssMinifier}`)
+      .use(ParcelCssMinifyPlugin);
   } else if (cssMinifier !== CSSMinifier.none) {
     throw new Error(`Unsupported cssMinifier ${userConfig.cssMinifier}.`);
   }

--- a/packages/bundler-webpack/src/plugins/ParcelCSSMinifyPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/ParcelCSSMinifyPlugin.ts
@@ -1,8 +1,8 @@
 import { transform, type TransformOptions } from '@parcel/css';
 import { Buffer } from 'buffer';
 import { join } from 'path';
-import type { Compilation, Compiler } from '../../compiled/webpack';
 import { RawSource, SourceMapSource } from '../../compiled/webpack-sources';
+import type { Compilation, Compiler } from '../../compiled/webpack/types';
 
 const pkgPath = join(__dirname, '../../package.json');
 const pkg = require(pkgPath);
@@ -12,7 +12,7 @@ type MinifyPluginOpts = Omit<TransformOptions, 'filename' | 'code' | 'minify'>;
 const PLUGIN_NAME = 'parcel-css-minify-plugin';
 const CSS_FILE_REG = /\.css(?:\?.*)?$/i;
 
-export class ParcelCssMinifyPlugin {
+export class ParcelCSSMinifyPlugin {
   private readonly options: MinifyPluginOpts;
 
   constructor(opts: MinifyPluginOpts = {}) {

--- a/packages/bundler-webpack/src/plugins/ParcelCssMinifyPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/ParcelCssMinifyPlugin.ts
@@ -1,0 +1,106 @@
+import { transform, type TransformOptions } from '@parcel/css';
+import { Buffer } from 'buffer';
+import { join } from 'path';
+import type { Compilation, Compiler } from '../../compiled/webpack';
+import { RawSource, SourceMapSource } from '../../compiled/webpack-sources';
+
+const pkgPath = join(__dirname, '../../package.json');
+const pkg = require(pkgPath);
+
+type MinifyPluginOpts = Omit<TransformOptions, 'filename' | 'code' | 'minify'>;
+
+const PLUGIN_NAME = 'parcel-css-minify-plugin';
+const CSS_FILE_REG = /\.css(?:\?.*)?$/i;
+
+export class ParcelCssMinifyPlugin {
+  private readonly options: MinifyPluginOpts;
+
+  constructor(opts: MinifyPluginOpts = {}) {
+    this.options = opts;
+  }
+
+  apply(compiler: Compiler) {
+    const meta = JSON.stringify({
+      name: pkg.name,
+      version: pkg.version,
+      options: this.options,
+    });
+
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.chunkHash.tap(PLUGIN_NAME, (_, hash) =>
+        hash.update(meta),
+      );
+
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: PLUGIN_NAME,
+          // @ts-ignore
+          stage: compilation.constructor.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
+          additionalAssets: true,
+        },
+        async () => await this.transformAssets(compilation),
+      );
+
+      compilation.hooks.statsPrinter.tap(PLUGIN_NAME, (statsPrinter) => {
+        statsPrinter.hooks.print
+          .for('asset.info.minimized')
+          // @ts-ignore
+          .tap(PLUGIN_NAME, (minimized, { green, formatFlag }) => {
+            // @ts-ignore
+            return minimized ? green(formatFlag('minimized')) : undefined;
+          });
+      });
+    });
+  }
+
+  private async transformAssets(compilation: Compilation): Promise<void> {
+    const {
+      options: { devtool },
+    } = compilation.compiler;
+
+    const sourcemap =
+      this.options.sourceMap === undefined
+        ? ((devtool && (devtool as string).includes('source-map')) as boolean)
+        : this.options.sourceMap;
+
+    const assets = compilation.getAssets().filter((asset) => {
+      return !asset.info.minimized && CSS_FILE_REG.test(asset.name);
+    });
+
+    await Promise.all(
+      assets.map(async (asset) => {
+        const { source, map } = asset.source.sourceAndMap();
+        const sourceAsString = source.toString();
+        const code = typeof source === 'string' ? Buffer.from(source) : source;
+
+        const result = await transform({
+          filename: asset.name,
+          code,
+          minify: true,
+          sourceMap: sourcemap,
+          ...this.options,
+        });
+        const codeString = result.code.toString();
+
+        compilation.updateAsset(
+          asset.name,
+          // @ts-ignore
+          sourcemap
+            ? new SourceMapSource(
+                codeString,
+                asset.name,
+                JSON.parse(result.map!.toString()),
+                sourceAsString,
+                map as any,
+                true,
+              )
+            : new RawSource(codeString),
+          {
+            ...asset.info,
+            minimized: true,
+          },
+        );
+      }),
+    );
+  }
+}

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -45,7 +45,7 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
       Joi.string().valid(
         CSSMinifier.cssnano,
         CSSMinifier.esbuild,
-        CSSMinifier.parcelCss,
+        CSSMinifier.parcelCSS,
         CSSMinifier.none,
       ),
     cssMinifierOptions: (Joi) => Joi.object(),

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -45,6 +45,7 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
       Joi.string().valid(
         CSSMinifier.cssnano,
         CSSMinifier.esbuild,
+        CSSMinifier.parcelCss,
         CSSMinifier.none,
       ),
     cssMinifierOptions: (Joi) => Joi.object(),

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -26,6 +26,7 @@ export enum JSMinifier {
 export enum CSSMinifier {
   esbuild = 'esbuild',
   cssnano = 'cssnano',
+  parcelCss = 'parcelCss',
   none = 'none',
 }
 

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -26,7 +26,7 @@ export enum JSMinifier {
 export enum CSSMinifier {
   esbuild = 'esbuild',
   cssnano = 'cssnano',
-  parcelCss = 'parcelCss',
+  parcelCSS = 'parcelCSS',
   none = 'none',
 }
 


### PR DESCRIPTION

可以预料到  parcel css 可以用来做 css 产物压缩。

实现这个功能。

可以看到 parcel 更聪明：

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/59400654/154973026-968b9254-7445-4879-97fc-819c9227f6e2.png">

速度上两者差不多。

