### PR TITLE
feat(plugin-docs): Improved <Message /> component styles

### DIFF
--- a/packages/plugin-docs/client/theme-doc/components/Message.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Message.tsx
@@ -31,17 +31,24 @@ function Message(props: PropsWithChildren<MessageProps>) {
       break;
   }
 
+  const messageText =
+    typeof props.children === 'string'
+      ? props.children
+      : (props.children as React.ReactElement).props.children;
+
   return (
     <>
       <div
-        className={`w-full py-3 px-4 ${bgColor} ${textColor} rounded-lg my-2`}
+        className={`w-full py-3 px-4 ${bgColor} ${textColor} rounded-lg my-4 mdx-message`}
       >
-        {props.emoji && (
-          <span role="img" className="mr-3">
-            {props.emoji}
-          </span>
-        )}
-        {props.children}
+        <p>
+          {props.emoji && (
+            <span role="img" className="mr-3 inline">
+              {props.emoji}
+            </span>
+          )}
+          {messageText}
+        </p>
       </div>
     </>
   );

--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -28,7 +28,7 @@ article h6 {
 }
 
 article p {
-  @apply text-base font-light leading-8 mt-4 text-gray-700 dark:text-white;
+  @apply text-base leading-8 mt-4 text-gray-700 dark:text-white;
 }
 
 article ul {
@@ -145,5 +145,9 @@ h1, h2, h3, h4, h5, h6 {
 
   .features::-webkit-scrollbar {
     display: none;
+  }
+
+  .mdx-message > p {
+    @apply mt-0;
   }
 }


### PR DESCRIPTION
写文档的过程中发现 `plugin-docs` 中的 `<Message />` 组件样式有点问题，因此进行修复：

1. 修复了组件中的文字样式被 `article > p` 影响导致带有 `margin-top` 的问题
2. 修复了组件有 emoji 时，emoji 和文字会出现在不同行的问题

修复后的样式：

<img width="1920" alt="Screen Shot 2022-02-23 at 3 11 58 PM" src="https://user-images.githubusercontent.com/21105863/155277149-a62b5f4b-bec6-4182-9ccc-c3cfdc0ab34d.png">

