### PR TITLE
fix(mfsu): esbuild alias match

### DIFF
--- a/packages/mfsu/src/babelPlugins/awaitImport/getAliasedPath.test.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/getAliasedPath.test.ts
@@ -1,0 +1,80 @@
+import { getAliasedPath } from './getAliasedPath';
+
+const alias = {
+  // exact
+  exact: {
+    // file
+    foo$: 'path/to/foo.js',
+    'foo-pkg$': 'path/to/foo-pkg.js',
+    // dir
+    'foo-dir$': 'path/to/foo',
+    // scope
+    '@scope/foo$': 'path/to/name.js',
+  },
+  // equal
+  equal: {
+    // file
+    foo: 'path/to/foo.js',
+    // dir
+    'foo-pkg': 'path/to/foo',
+    // scope - file
+    '@scope/name': 'path/to/name.js',
+    // scope - dir
+    '@scope/name-pkg': 'path/to/name',
+  },
+  // prefix
+  prefix: {
+    // file
+    react: 'path/to/react.js',
+    'react-dom': 'path/to/react-dom.js',
+    // dir
+    foo: 'path/to/foo',
+    'foo-pkg': 'path/to/foo-pkg',
+    // scope - file
+    '@scope/name': 'path/to/name.js',
+    // scope - dir
+    '@scope/foo': 'path/to/scope/foo',
+    '@scope/name-pkg': 'path/to/name',
+  },
+};
+
+test('alias: exact', () => {
+  const check = (v: string) => {
+    const imported = getAliasedPath({ value: v, alias: alias.exact });
+    const expectImported = alias.exact[`${v}$`];
+    expect(imported).toEqual(expectImported);
+  };
+  Object.keys(alias.exact).forEach((v) => {
+    check(v.slice(0, -1));
+  });
+});
+
+test('alias: equal', () => {
+  const check = (v: string) => {
+    const imported = getAliasedPath({ value: v, alias: alias.equal });
+    const expectImported = alias.equal[v];
+    expect(imported).toEqual(expectImported);
+  };
+  Object.keys(alias.equal).forEach((v) => {
+    check(v);
+  });
+});
+
+test('alias: prefix', () => {
+  const getImported = (v: string) => {
+    return getAliasedPath({ value: v, alias: alias.prefix });
+  };
+  Object.keys(alias.prefix).forEach((v) => {
+    const imported = getImported(v);
+    const expectImported = alias.prefix[v];
+    expect(imported).toEqual(expectImported);
+  });
+  // check dir alias with sub path
+  expect(getImported('foo/sub')).toEqual('path/to/foo/sub');
+  expect(getImported('foo/')).toEqual('path/to/foo/');
+  expect(getImported('foo-pkg/sub')).toEqual('path/to/foo-pkg/sub');
+  expect(getImported('@scope/foo/sub')).toEqual('path/to/scope/foo/sub');
+  expect(getImported('@scope')).toEqual(undefined);
+  expect(getImported('@scope/foo/sub/')).toEqual('path/to/scope/foo/sub/');
+  expect(getImported('@scope/name-pkg/sub')).toEqual('path/to/name/sub');
+});

--- a/packages/mfsu/src/babelPlugins/awaitImport/getAliasedPath.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/getAliasedPath.ts
@@ -1,5 +1,3 @@
-import { extname } from 'path';
-
 export function getAliasedPath({
   value,
   alias,
@@ -8,6 +6,10 @@ export function getAliasedPath({
   alias: Record<string, string>;
 }) {
   const importValue = value;
+  // equal alias
+  if (alias[value]) {
+    return alias[value];
+  }
   for (const key of Object.keys(alias)) {
     const aliasValue = alias[key];
 
@@ -19,21 +21,11 @@ export function getAliasedPath({
       else continue;
     }
 
-    // e.g. foo: path/to/foo
-    if (importValue === key) {
-      return aliasValue;
-    }
-
     // e.g. foo: path/to/foo.js
-    const slashedKey = isJSFile(aliasValue) ? key : addLastSlash(key);
-    if (importValue.startsWith(slashedKey)) {
+    if (importValue.startsWith(addLastSlash(key))) {
       return importValue.replace(key, aliasValue);
     }
   }
-}
-
-function isJSFile(path: string) {
-  return ['.js', '.jsx', '.ts', '.tsx'].includes(extname(path));
 }
 
 function addLastSlash(path: string) {


### PR DESCRIPTION
主要为了解决：

```js
  alias: {
    'react': 'some.js'
  }
```

会匹配到 `react-dom` 类型的问题：

```js
  import 'react-dom'
  // -> import 'some.js-dom' 😭
```