### PR TITLE
fix(plugin-docs): fix color behavior of Message component

### DIFF
--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -25,7 +25,7 @@ export default () => {
   return (
     <div>
       <div
-        className="w-24 rounded-lg overflow-hidden cursor-pointer border
+        className="w-24 rounded-lg overflow-hidden cursor-pointer border text-center
        border-white hover:border-gray-100 dark:border-gray-800"
         onClick={handleClick}
       >

--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -75,7 +75,7 @@ export default (props: any) => {
               className="w-full flex flex-row justify-center overflow-x-hidden"
             >
               <div className="container flex flex-row justify-center">
-                <div className="w-full lg:w-1/2 px-4 lg:px-0 m-8 z-20 lg:py-12">
+                <div className="w-full lg:w-1/2 px-4 lg:px-2 m-8 z-20 lg:py-12">
                   <article className="flex-1">{props.children}</article>
                 </div>
               </div>

--- a/packages/plugin-docs/client/theme-doc/Logo.tsx
+++ b/packages/plugin-docs/client/theme-doc/Logo.tsx
@@ -3,13 +3,12 @@ import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
 
 export default () => {
-  
   const { themeConfig, components } = useThemeContext()!;
   const { isFromPath, currentLanguage } = useLanguage();
-  
+
   // @ts-ignore
   const { logo } = themeConfig;
-  
+
   return (
     <components.Link to={isFromPath ? '/' + currentLanguage?.locale : '/'}>
       <div className="flex flex-row items-center">

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -36,9 +36,9 @@ export default () => {
   return (
     <div
       className={cx(
-        'md:w-12 md:h-6 w-12 h-4 flex items-center bg-gray-300 rounded-full ',
+        'md:w-12 md:h-6 w-12 h-4 flex items-center rounded-full ',
         'py-1 px-1.5  cursor-pointer',
-        toggle ? 'bg-blue-300' : 'bg-gray-700',
+        toggle ? 'bg-gray-100' : 'bg-gray-700',
       )}
       onClick={() => setToggle(!toggle)}
     >

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -40,7 +40,7 @@ export default () => {
       <p className="text-lg font-extrabold dark:text-white">
         {route.titles[0].title}
       </p>
-      <ul className="max-h-[calc(100vh-360px)] overflow-y-scroll py-2">
+      <ul className="max-h-[calc(100vh-360px)] overflow-y-auto py-2">
         {titles.map((item: any) => {
           return (
             <li

--- a/packages/plugin-docs/client/theme-doc/components/Message.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Message.tsx
@@ -13,22 +13,21 @@ interface MessageProps {
 }
 
 function Message(props: PropsWithChildren<MessageProps>) {
-  let bgColor = 'bg-blue-50';
-  let textColor = 'text-blue-900';
+  const messageType = props.type || 'info';
 
-  switch (props.type) {
+  let messageClass: string;
+  switch (messageType) {
     case MessageType.Success:
-      bgColor = 'bg-green-50';
-      textColor = 'text-green-900';
+      messageClass = 'mdx-message-success';
       break;
     case MessageType.Warning:
-      bgColor = 'bg-orange-50';
-      textColor = 'text-orange-900';
+      messageClass = 'mdx-message-warning';
       break;
     case MessageType.Error:
-      bgColor = 'bg-red-50';
-      textColor = 'text-red-900';
+      messageClass = 'mdx-message-error';
       break;
+    default:
+      messageClass = 'mdx-message-info';
   }
 
   const messageText =
@@ -39,7 +38,7 @@ function Message(props: PropsWithChildren<MessageProps>) {
   return (
     <>
       <div
-        className={`w-full py-3 px-4 ${bgColor} ${textColor} rounded-lg my-4 mdx-message`}
+        className={`w-full py-3 px-4 rounded-lg my-4 mdx-message ${messageClass}`}
       >
         <p>
           {props.emoji && (

--- a/packages/plugin-docs/client/theme-doc/firefox-polyfill.css
+++ b/packages/plugin-docs/client/theme-doc/firefox-polyfill.css
@@ -3,7 +3,8 @@
   https://www.cnblogs.com/coco1s/p/14953143.html
 */
 
-.g-glossy-firefox, .g-glossy-firefox-cover {
+.g-glossy-firefox,
+.g-glossy-firefox-cover {
   display: none;
 }
 

--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -84,12 +84,18 @@ article a code {
 
 article a {
   @apply text-blue-600 mx-1 hover:text-blue-300 transition dark:text-blue-400;
-  background-image: linear-gradient(transparent 60%, rgba(130, 199, 255, 0.28) 55%);
+  background-image: linear-gradient(
+    transparent 60%,
+    rgba(130, 199, 255, 0.28) 55%
+  );
 }
 
 .link-with-underline {
   @apply text-blue-600 mx-1 hover:text-blue-300 transition dark:text-blue-400;
-  background-image: linear-gradient(transparent 60%, rgba(130, 199, 255, 0.28) 55%);
+  background-image: linear-gradient(
+    transparent 60%,
+    rgba(130, 199, 255, 0.28) 55%
+  );
 }
 
 /*article pre {*/
@@ -111,7 +117,7 @@ article hr {
 }
 
 html {
-  scroll-behavior: smooth
+  scroll-behavior: smooth;
 }
 
 :root {
@@ -119,12 +125,16 @@ html {
 }
 
 /** Anchor with offset for headings */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   scroll-margin-top: calc(var(--anchor-offset) + 88px);
 }
 
 @layer components {
-
   .features-dark {
     @apply bg-gray-900;
     background-image: radial-gradient(#2a2a2a 20%, transparent 20%);
@@ -147,7 +157,43 @@ h1, h2, h3, h4, h5, h6 {
     display: none;
   }
 
+  .mdx-message {
+    @apply border-l-8;
+  }
+
   .mdx-message > p {
     @apply mt-0;
+  }
+
+  .mdx-message-info {
+    @apply bg-blue-50 border-blue-300 dark:bg-blue-100 dark:border-blue-500;
+  }
+
+  .mdx-message-info > p {
+    @apply text-blue-900 dark:text-blue-900;
+  }
+
+  .mdx-message-success {
+    @apply bg-green-50 border-green-300 dark:bg-green-100 dark:border-green-500;
+  }
+
+  .mdx-message-success > p {
+    @apply text-green-900 dark:text-green-900;
+  }
+
+  .mdx-message-warning {
+    @apply bg-orange-50 border-orange-300 dark:bg-orange-100 dark:border-orange-500;
+  }
+
+  .mdx-message-warning > p {
+    @apply text-orange-900 dark:text-orange-900;
+  }
+
+  .mdx-message-error {
+    @apply bg-red-50 border-red-300 dark:bg-red-100 dark:border-red-500;
+  }
+
+  .mdx-message-error > p {
+    @apply text-red-900 dark:text-red-900;
   }
 }


### PR DESCRIPTION
文档的 Message 组件在夜间模式下的颜色表现出现了一些问题，这源于 `.dark article p` 的样式覆盖了它预期的样式。在此 PR 中修复了这个问题。

除此之外，此 PR 还做了这些事情：

- 适配了 Message 组件的 `info`, `success`, `warning` 和 `error` 样式。[check](https://github.com/umijs/umi-next/pull/402/files#diff-44bee362b0587d23f89199098f0eb298691b4b43ff8efe840f66358180db87acR160-R198)
- 当文档的 Toc 高度未超出 `max-height` 时，不再显示 y 轴的滚动条。[check](https://github.com/umijs/umi-next/pull/402/files#diff-de7a15c3c1f187cd22648a21c9c3670ddb8cbc02fa4fc8af81c63775d2699e98L43-R43)
- 优化切换主题模式按钮在日间模式的背景颜色。[check](https://github.com/umijs/umi-next/pull/402/files#diff-cc6ba0b692ab5909a17148d509a4341a308cfc860113fad0028cf1e552071ea4L41-R41)
- 水平居中对齐切换语言按钮文本内容。[check](https://github.com/umijs/umi-next/pull/402/files#diff-bc731492b883fc938b1c69e564f42cd9c5df36bd475728b705b66aa81dd7aa31L28-R28)
- 设置正文内容在 `lg` 断点的横向 `padding`。[check](https://github.com/umijs/umi-next/pull/402/files#diff-a446bfffad248cbae7a0bab4c46a514c86cbdd383ed021145f545c20b7cef1f9L78-R78)