### PR TITLE
fix: antd:config is not allowed

### DIFF
--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -79,7 +79,7 @@ export default (api: IApi) => {
 
   // antd config provider
   api.onGenerateFiles(() => {
-    if (!api.config.antd.config) return;
+    if (!api.config.antd.configProvider) return;
     api.writeTmpFile({
       path: `runtime.tsx`,
       content: Mustache.render(
@@ -103,13 +103,13 @@ export function rootContainer(container) {
 }
       `.trim(),
         {
-          config: JSON.stringify(api.config.antd.config),
+          config: JSON.stringify(api.config.antd.configProvider),
         },
       ),
     });
   });
   api.addRuntimePlugin(() => {
-    return api.config.antd.config
+    return api.config.antd.configProvider
       ? [withTmpPath({ api, path: 'runtime.tsx' })]
       : [];
   });


### PR DESCRIPTION
antd 配置变更，antd:config 修改为 antd:configProvider
```
AssertionError [ERR_ASSERTION]: Invalid config values: antd
Invalid value for antd:
"config" is not allowed
```