### PR TITLE
fix(plugin-docs): Remember user language setting in localstorage

### DIFF
--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -1,9 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useLanguage from './useLanguage';
 
 export default () => {
-  const { currentLanguage, languages, switchLanguage } = useLanguage();
+  const { currentLanguage, languages, switchLanguage, isFromPath } =
+    useLanguage();
   const [isExpanded, setExpanded] = useState(false);
+
+  // 首次加载时，根据 localstorage 记录的上次语言自动切换
+  useEffect(() => {
+    const locale = window.localStorage.getItem('umi_locale');
+    if (locale && !isFromPath) switchLanguage(locale);
+  }, []);
 
   if (!currentLanguage) {
     return null;

--- a/packages/plugin-docs/client/theme-doc/useLanguage.ts
+++ b/packages/plugin-docs/client/theme-doc/useLanguage.ts
@@ -35,12 +35,15 @@ function useLanguage(): useLanguageResult {
 
     // 切换到默认语言
     if (locale === languages[0].locale && isFromPath) {
+      window.localStorage.removeItem('umi_locale');
       let p = location.pathname.split('/');
       p.shift();
       p.shift();
       history.push('/' + p.join('/'));
       return;
     }
+
+    window.localStorage.setItem('umi_locale', locale);
 
     // 当前在默认语言，切换到其他语言
     if (!isFromPath) {


### PR DESCRIPTION
对 `plugin-docs` 的 `theme-doc` 做了小改进：

当用户切换语言后，会将语言保存在 local storage 中，
下次访问网站时，若路由输入的是默认语言，会自动切换到上次选择的语言中。

这个避免了每次用网址访问 https://next.umijs.org 都会跳回默认语言的问题。