### PR TITLE
fix(preset-umi): page template styles path error

### DIFF
--- a/packages/preset-umi/templates/generate/page/index.tsx.tpl
+++ b/packages/preset-umi/templates/generate/page/index.tsx.tpl
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './{{{ name }}}{{{ cssExt }}}';
+import styles from './index{{{ cssExt }}}';
 
 export default function Page() {
   return (


### PR DESCRIPTION
在使用 generate page 中发现页面模板中的 less 路径使用了 name 作为名称，这将是错误的路径，修改为 index