### PR TITLE
chore(docs): ✏️ no more Bpm typo

### DIFF
--- a/docs/docs/tutorials/getting-started.md
+++ b/docs/docs/tutorials/getting-started.md
@@ -48,7 +48,7 @@ $ mkdir myapp && cd myapp
 $ pnpx create-umi@next
 ✔ Install the following package: create-umi@next? (Y/n) · true
 ✔ Pick Npm Client › pnpm
-✔ Pick Bpm Registry › taobao
+✔ Pick Npm Registry › taobao
 Write: .gitignore
 Write: .npmrc
 Write: .umirc.ts


### PR DESCRIPTION
no more  `bpm` in code

```
$git grep -il bpm
examples/bundler-vite-demo/src/logo.svg
packages/bundler-webpack/compiled/webpack-bundle-analyzer/public/viewer.js.map
pnpm-lock.yaml
```