### PR TITLE
fix(plugins): tailwindcss child process  not exit

### DIFF
--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -22,5 +22,10 @@ export default (api: IApi) => {
 
     /** 将生成的 css 文件加入到 import 中 */
     api.addEntryImports(() => [{ source: generatedPath }]);
+
+    /** 构建完成需要退出子进程，否则会一直等待 */
+    api.onBuildComplete(() => {
+      tailwind.kill('SIGTERM');
+    });
   });
 };


### PR DESCRIPTION
**问题：** 在使用 tailwindcss 插件时，build 构建完成会处于等待状态，这是因为 tailwindcss 子进程仍在进行中
**处理：** 监听 onBuildComplete 关闭 tailwindcss 子进程
**相关issue:**  #434 