### PR TITLE
fix(plugin-docs): Fix doc-theme search input bugs

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -65,7 +65,7 @@ export default () => {
       <div
         className="rounded-lg w-40 lg:w-64 flex items-center pr-2 flex-row hover:bg-gray-50
      transition duration-300 bg-gray-100 border border-white focus-within:border-gray-100
-     focus-within:bg-white dark:bg-gray-700 dark:border-gray-700
+     focus-within:bg-white dark:bg-gray-700 dark:border-gray-700 relative
      dark:focus-within:border-gray-700 dark:focus-within:bg-gray-800 dark:text-gray-100"
       >
         <input
@@ -85,7 +85,7 @@ export default () => {
         </div>
         <div
           className={cx(
-            'absolute transition-all duration-500 top-16 w-96 rounded-lg',
+            'absolute transition-all duration-500 top-12 w-96 rounded-lg',
             'cursor-pointer shadow overflow-hidden',
             result.length > 0 && isFocused ? 'max-h-80' : 'max-h-0',
           )}

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -74,7 +74,7 @@ export default () => {
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           id="search-input"
-          className="w-full bg-transparent outline-0 text-sm px-4 py-2 "
+          className="w-full bg-transparent outline-none text-sm px-4 py-2 "
           placeholder={render('Search anything ...')}
         />
         <div


### PR DESCRIPTION
修复了 `plugin-docs` 的 `theme-doc` 中的两个问题：

### 1. 搜索框在 Chrome 浏览器下位置错误的问题

Before

<img width="619" alt="Screen Shot 2022-03-08 at 4 41 08 PM" src="https://user-images.githubusercontent.com/21105863/157199938-3d3d02ed-9d58-4540-92b7-d377612eb8f0.png">

After

<img width="619" alt="Screen Shot 2022-03-08 at 4 41 18 PM" src="https://user-images.githubusercontent.com/21105863/157199969-5aa06172-4c88-449e-852a-66a8a81fb270.png">

### 2. 搜索框在 Firefox 浏览器下有 outline

Before

<img width="698" alt="Screen Shot 2022-03-08 at 4 40 15 PM" src="https://user-images.githubusercontent.com/21105863/157200243-8b2b57d3-33c7-4c9a-bac5-285b063384ac.png">

After

<img width="698" alt="Screen Shot 2022-03-08 at 4 40 32 PM" src="https://user-images.githubusercontent.com/21105863/157200272-9294cd2f-8fbd-41b1-83be-a835e7d6ac00.png">

