### PR TITLE
fix(api-routes): Fix `watch` in api-route causing `umi build` cannot exit

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/apiRoute.ts
+++ b/packages/preset-umi/src/features/apiRoute/apiRoute.ts
@@ -166,24 +166,28 @@ export default (api: IApi) => {
   // 编译时，将打包好的临时文件根据用户指定的目标平台进行打包
   api.onBeforeCompiler(async () => {
     // 当有新的 API 路由或是原有的路由被删除时，必须重启服务，因为 appData 内的 apiRoutes 没有更新
-    watch({
-      path: join(api.paths.absApiRoutesPath),
-      addToUnWatches: true,
-      onChange(e, p) {
-        if (e === 'add') {
-          logger.event(`New API route ${basename(p)} detected, compiling ...`);
-          api.restartServer();
-          return;
-        }
-        if (e === 'unlink') {
-          logger.event(
-            `API route ${basename(p)} has been removed, compiling ...`,
-          );
-          api.restartServer();
-          return;
-        }
-      },
-    });
+    if (api.env === 'development') {
+      watch({
+        path: join(api.paths.absApiRoutesPath),
+        addToUnWatches: true,
+        onChange(e, p) {
+          if (e === 'add') {
+            logger.event(
+              `New API route ${basename(p)} detected, compiling ...`,
+            );
+            api.restartServer();
+            return;
+          }
+          if (e === 'unlink') {
+            logger.event(
+              `API route ${basename(p)} has been removed, compiling ...`,
+            );
+            api.restartServer();
+            return;
+          }
+        },
+      });
+    }
 
     const apiRoutePaths = Object.keys(api.appData.apiRoutes).map((key) =>
       join(api.paths.absTmpPath, 'api', api.appData.apiRoutes[key].file),


### PR DESCRIPTION
修复了由于在 `api.onBeforeCompiler` 启用了监听导致 `umi build` 无法顺利结束进程的问题