### PR TITLE
feat(api-routes-vercel): Check there is `vercel.json` if user want to use API routes in Vercel

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/apiRoute.ts
+++ b/packages/preset-umi/src/features/apiRoute/apiRoute.ts
@@ -76,6 +76,22 @@ export default (api: IApi) => {
         return false;
       }
 
+      // 如果是 Vercel 平台，则需要检查是否有配置了 Vercel 配置
+      if (!fs.existsSync(join(api.paths.cwd, 'vercel.json'))) {
+        logger.warn(
+          'You have enabled the API route feature, but there is no vercel.json file in your work directory! ' +
+            'Automatically creating a vercel.json file ...',
+        );
+        fs.writeFileSync(
+          join(api.paths.cwd, 'vercel.json'),
+          JSON.stringify(
+            { build: { env: { ENABLE_FILE_SYSTEM_API: '1' } } },
+            null,
+            2,
+          ),
+        );
+      }
+
       return true;
     },
   });


### PR DESCRIPTION
若用户启用了 API 路由功能，且设置了部署平台为 Vercel，则检查工作目录下是否有 `vercel.json` 文件，没有的话自动生成一个。避免用户部署上去以后由于没有 `vercel.json` 中设置的 `ENABLE_FILE_SYSTEM_API: "1` 导致 API 路由不生效。