### PR TITLE
feat(api-routes): Netlify adapter

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/netlify/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/netlify/esbuild.ts
@@ -1,0 +1,19 @@
+import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import { resolve } from 'path';
+import type { IApi } from '../../../types';
+import { esbuildIgnorePathPrefixPlugin } from '../utils';
+
+// 将 API 路由的临时文件打包为 Vercel 的 Serverless Function 可以使用的格式
+export default async function (api: IApi, apiRoutePaths: string[]) {
+  await esbuild.build({
+    format: 'esm',
+    outExtension: { '.js': '.mjs' },
+    bundle: true,
+    entryPoints: [
+      ...apiRoutePaths,
+      resolve(api.paths.absTmpPath, 'api/_middlewares.ts'),
+    ],
+    outdir: resolve(api.paths.cwd, 'netlify/functions'),
+    plugins: [esbuildIgnorePathPrefixPlugin()],
+  });
+}

--- a/packages/preset-umi/templates/apiRoute/netlify.tpl
+++ b/packages/preset-umi/templates/apiRoute/netlify.tpl
@@ -1,0 +1,10 @@
+const handler = async (event, context) => {
+
+return {
+statusCode: 200,
+body: JSON.stringify({ message: "Hello World" }),
+};
+
+};
+
+export { handler };

--- a/packages/preset-umi/templates/apiRoute/vercel.tpl
+++ b/packages/preset-umi/templates/apiRoute/vercel.tpl
@@ -4,10 +4,10 @@ import { UmiApiRequest, UmiApiResponse } from "{{{ adapterPath }}}";
 
 export default async (req, res) => {
 
-  const umiReq = new UmiApiRequest(req);
-  await umiReq.readBody();
-  const umiRes = new UmiApiResponse(res);
-  await new Promise((resolve) => _middlewares(umiReq, umiRes, resolve));
-  await handler(umiReq, umiRes);
+const umiReq = new UmiApiRequest(req);
+await umiReq.readBody();
+const umiRes = new UmiApiResponse(res);
+await new Promise((resolve) => _middlewares(umiReq, umiRes, resolve));
+await handler(umiReq, umiRes);
 
 }


### PR DESCRIPTION
支持将 API 路由部署到 [Netlify](https://www.netlify.com) 平台上。

参考：https://docs.netlify.com/functions/overview/