### PR TITLE
ci: use `turbo` run test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 .DS_Store
 .turbo
 *.tsbuildinfo
+.jest-cache
+.swc

--- a/examples/with-react-query/package.json
+++ b/examples/with-react-query/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/react-query",
+  "name": "@example/with-react-query",
   "private": true,
   "scripts": {
     "build": "umi build",

--- a/examples/with-react-three-fiber/package.json
+++ b/examples/with-react-three-fiber/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/react-three-fiber",
+  "name": "@example/with-react-three-fiber",
   "private": true,
   "scripts": {
     "build": "umi build",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,10 +1,15 @@
 import { Config, createConfig } from 'umi/test';
 
+const cwd = process.cwd();
+
 export default {
   ...createConfig(),
-  testMatch: ['**/packages/*/src/**/*.test.ts'],
+  rootDir: cwd,
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
   modulePathIgnorePatterns: [
-    '<rootDir>/packages/.+/compiled',
-    '<rootDir>/packages/.+/fixtures',
+    '<rootDir>/compiled',
+    '<rootDir>/fixtures',
+    '<rootDir>/bundles',
   ],
+  cacheDirectory: `${cwd}/.jest-cache`,
 } as Config.InitialOptions;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "setup:webstorm": "esno scripts/setupWebStorm.ts",
     "test": "esno scripts/turbo.ts --cmd test --parallel",
     "test:clean": "esno scripts/turbo.ts --cmd test --no-cache --parallel -- --clearCache",
-    "tsc:check": "tsc --noEmit"
+    "tsc:check": "tsc --noEmit",
+    "turbo:clean": "rimraf .turbo"
   },
   "lint-staged": {
     "*.{jsx,less,md,json}": [

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "prepare": "husky install",
     "release": "esno scripts/release.ts",
     "setup:webstorm": "esno scripts/setupWebStorm.ts",
-    "test": "jest",
-    "test:clean": "jest --clearCache",
+    "test": "esno scripts/turbo.ts --cmd test --parallel",
+    "test:clean": "esno scripts/turbo.ts --cmd test --no-cache --parallel -- --clearCache",
     "tsc:check": "tsc --noEmit"
   },
   "lint-staged": {

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@umijs/bundler-utils": "4.0.0-rc.5"

--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -30,8 +30,6 @@ test('set number', () => {
 });
 
 test('set array', () => {
-  throw new Error('c');
-
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
   const generateCode = generate(

--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -39,6 +39,7 @@ test('set array', () => {
 });
 
 test('set new config', () => {
+  throw new Error('ccc');
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
   const generateCode = generate(setConfigByName(ast, 'aaa', true)!);

--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -30,6 +30,8 @@ test('set number', () => {
 });
 
 test('set array', () => {
+  throw new Error('c');
+
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
   const generateCode = generate(

--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -39,7 +39,6 @@ test('set array', () => {
 });
 
 test('set new config', () => {
-  throw new Error('ccc');
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
   const generateCode = generate(setConfigByName(ast, 'aaa', true)!);

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@babel/runtime": "7.17.2",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@umijs/bundler-utils": "4.0.0-rc.5",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@svgr/core": "6.2.1",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -25,7 +25,8 @@
     "build:client": "pnpm tsc --project ./tsconfig.client.json",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
     "dev": "pnpm build -- --watch",
-    "generate:webpackPackages": "zx ./scripts/generateWebpackPackages.mjs"
+    "generate:webpackPackages": "zx ./scripts/generateWebpackPackages.mjs",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@parcel/css": "1.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@umijs/bundler-utils": "4.0.0-rc.5",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@umijs/utils": "4.0.0-rc.5"

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@umijs/bundler-esbuild": "4.0.0-rc.5",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -21,7 +21,8 @@
     "build:css": "tailwindcss -i ./client/theme-doc/tailwind.css -o ./client/theme-doc/tailwind.out.css",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
     "build:extra": "pnpm build:css",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "keymaster": "1.6.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@ahooksjs/use-request": "^2.0.0",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "@types/multer": "1.4.7",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "pnpm tsc",
     "build:deps": "pnpm esno ../../scripts/bundleDeps.ts",
-    "dev": "pnpm build -- --watch"
+    "dev": "pnpm build -- --watch",
+    "test": "jest -c ../../jest.config.ts"
   },
   "dependencies": {
     "chokidar": "3.5.3"

--- a/scripts/turbo.ts
+++ b/scripts/turbo.ts
@@ -1,3 +1,4 @@
+import * as logger from '@umijs/utils/src/logger';
 import spawn from '@umijs/utils/compiled/cross-spawn';
 import yArgs from '@umijs/utils/compiled/yargs-parser';
 import { join } from 'path';
@@ -30,8 +31,9 @@ async function cmd(command: string) {
   });
   if (result.status !== 0) {
     // sub package command don't stop when execute fail.
-    // display throw error
-    throw new Error('Execute command error');
+    // display exit
+    logger.error(`Execute command error (${command})`);
+    process.exit(1);
   }
   return result;
 }

--- a/scripts/turbo.ts
+++ b/scripts/turbo.ts
@@ -58,7 +58,9 @@ async function turbo(opts: {
     extraCmd,
     cacheCmd,
     parallelCmd,
-  ].join(' ');
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return cmd(`turbo run ${options}`);
 }

--- a/scripts/turbo.ts
+++ b/scripts/turbo.ts
@@ -28,11 +28,11 @@ async function cmd(command: string) {
     shell: true,
     cwd: join(__dirname, '../'),
   });
-  // if (result.status !== 0) {
-  // sub package command don't stop when execute fail.
-  // display throw error
-  //   throw new Error('Execute command error')
-  // }
+  if (result.status !== 0) {
+    // sub package command don't stop when execute fail.
+    // display throw error
+    throw new Error('Execute command error');
+  }
   return result;
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,9 @@
     },
     "dev": {
       "cache": false
+    },
+    "test": {
+      "outputs": [".jest-cache/**"]
     }
   },
   "globalDependencies": ["tsconfig.base.json", "tsconfig.json"]


### PR DESCRIPTION
#### 做法

1. 把 `test` 命令拆解到子包里，此时：

   i. 子包 `src` 里面没有 `*.test.ts` 的不添加 `test` script，否则在子包里运行找不到任何测试文件会报错，为了保证成立，使用 `scripts/checkPackageFiles.ts` 来做自动校验和添加 script

   ii. 变更 `jest.config.ts` 中配置，变成针对每个子项目的匹配模式

2. 使用 `turbo` 跑 test 命令，为了实现缓存：把 jest 缓存放到子包里（`.gitignore` 忽略掉该缓存目录），然后 `turbo` 来缓存 jest 的缓存，这样只要代码 hash 不变，上次的 jest 缓存就会自动复活
