### PR TITLE
refactor(preset-umi): move route middleware to the back

### DIFF
--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -246,7 +246,7 @@ PORT=8888 umi dev
           ...beforeMiddlewares,
           faviconMiddleware,
         ]),
-        afterMiddlewares: [createRouteMiddleware({ api })].concat(middlewares),
+        afterMiddlewares: middlewares.concat(createRouteMiddleware({ api })),
         onDevCompileDone(opts: any) {
           printMemoryUsage();
           api.applyPlugins({


### PR DESCRIPTION
## Description

将 `RouteMiddleware` 挪到最后，以便插件有时机在 `CompileMiddleware` 和 `RouteMiddleware` 中间做请求处理