### PR TITLE
feat: umi generate page support nested folder and  --dir option

### DIFF
--- a/packages/core/src/service/generator.ts
+++ b/packages/core/src/service/generator.ts
@@ -26,7 +26,7 @@ export interface IGeneratorOpts {
           target: string;
           data?: any;
           questions?: prompts.PromptObject[];
-        }): void;
+        }): Promise<void>;
       };
       updatePackageJSON: {
         (opts: { opts: object; cwd?: string }): void;

--- a/packages/preset-umi/src/commands/generate/page.test.ts
+++ b/packages/preset-umi/src/commands/generate/page.test.ts
@@ -2,9 +2,11 @@ import { Env, Service } from '@umijs/core';
 import { rimraf } from '@umijs/utils';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { PageGenerator } from './page';
 
 const fixtures = join(__dirname, '../../../fixtures');
 const cwd = join(fixtures, 'generate');
+
 async function runGenerator(args: any) {
   const service = new Service({
     cwd,
@@ -20,6 +22,7 @@ async function runGenerator(args: any) {
 test('generate page', async () => {
   await runGenerator({
     _: ['generate', 'page', 'index'],
+    dir: true,
   });
   expect(existsSync(join(cwd, 'pages', 'index', 'index.tsx'))).toEqual(true);
   expect(existsSync(join(cwd, 'pages', 'index', 'index.less'))).toEqual(true);
@@ -32,4 +35,95 @@ test('Generator not found', async () => {
       _: ['generate', 'foo'],
     }),
   ).rejects.toThrow(/Generator foo not found/);
+});
+
+describe('page generator', function () {
+  describe('in Non dir Mode', function () {
+    it('generate page files page', async () => {
+      await expectPageGeneratorArgsMatchesGeneratedFiles(
+        { _: ['page', 'foo'], dir: false },
+        [
+          {
+            target: '/pages/foo.tsx',
+            path: 'templates/generate/page/index.tsx.tpl',
+            name: 'foo',
+          },
+          {
+            target: '/pages/foo.less',
+            path: 'templates/generate/page/index.less.tpl',
+            name: 'foo',
+          },
+        ],
+      );
+    });
+
+    it('generate nested folder and page files', async () => {
+      await expectPageGeneratorArgsMatchesGeneratedFiles(
+        { _: ['page', 'foo/bar'], dir: false },
+        [
+          {
+            target: '/pages/foo/bar.tsx',
+            path: 'templates/generate/page/index.tsx.tpl',
+            name: 'bar',
+          },
+          {
+            target: '/pages/foo/bar.less',
+            path: 'templates/generate/page/index.less.tpl',
+            name: 'bar',
+          },
+        ],
+      );
+    });
+  });
+
+  describe('in dir mode', function () {
+    it('generate index files in folder', async () => {
+      await expectPageGeneratorArgsMatchesGeneratedFiles(
+        { _: ['page', 'foo'], dir: true },
+        [
+          {
+            target: '/pages/foo',
+            path: 'templates/generate/page',
+            name: 'index',
+          },
+        ],
+      );
+    });
+
+    it('generate nested folder and index files', async () => {
+      await expectPageGeneratorArgsMatchesGeneratedFiles(
+        { _: ['page', 'foo/bar'], dir: true },
+        [
+          {
+            target: '/pages/foo/bar',
+            path: 'templates/generate/page',
+            name: 'index',
+          },
+        ],
+      );
+    });
+  });
+
+  async function expectPageGeneratorArgsMatchesGeneratedFiles(
+    args: { _: string[]; dir: boolean },
+    fileGenerations: { name: string; target: string; path: string }[],
+  ) {
+    const generateFile = jest.fn().mockResolvedValue(null);
+    const g = new PageGenerator({
+      absPagesPath: '/pages/',
+      args,
+      generateFile,
+    });
+
+    await g.run();
+
+    expect(generateFile).toBeCalledTimes(fileGenerations.length);
+    for (const [i, f] of fileGenerations.entries()) {
+      expect(generateFile).toHaveBeenNthCalledWith(i + 1, {
+        data: { name: f.name, color: expect.anything(), cssExt: '.less' },
+        target: f.target,
+        path: expect.stringMatching(f.path),
+      });
+    }
+  }
 });

--- a/packages/preset-umi/templates/generate/page/index.tsx.tpl
+++ b/packages/preset-umi/templates/generate/page/index.tsx.tpl
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './index{{{ cssExt }}}';
+import styles from './{{{name}}}{{{ cssExt }}}';
 
 export default function Page() {
   return (

--- a/packages/utils/src/BaseGenerator/BaseGenerator.test.ts
+++ b/packages/utils/src/BaseGenerator/BaseGenerator.test.ts
@@ -6,31 +6,38 @@ import generateFile from './generateFile';
 const fixtures = join(__dirname, './fixtures');
 const cwd = join(fixtures, 'generate');
 
+const globKeepDotFile = join(cwd, '*');
+
+beforeEach(() => {
+  rimraf.sync(globKeepDotFile, { glob: { ignore: ['**/.gitkeep'] } });
+});
+
+afterAll(() => {
+  rimraf.sync(globKeepDotFile, { glob: { ignore: ['**/.gitkeep'] } });
+});
+
 test('generate tpl', async () => {
   await generateFile({
     path: join(fixtures, 'tpl'),
     target: join(cwd, 'hello/', ''),
   });
   expect(existsSync(join(cwd, 'hello', 'index.tsx'))).toEqual(true);
-  rimraf.sync(join(cwd, 'hello'));
 });
 
 test('generate tpl file', async () => {
   await generateFile({
     path: join(fixtures, 'tpl', 'index.tsx.tpl'),
-    target: join(cwd, 'file-tpl'),
+    target: join(cwd, 'file-tpl', 'index.tsx'),
   });
   expect(existsSync(join(cwd, 'file-tpl', 'index.tsx'))).toEqual(true);
-  rimraf.sync(join(cwd, 'file-tpl'));
 });
 
 test('generate by file', async () => {
   await generateFile({
     path: join(fixtures, 'tpl', 'a.tsx'),
-    target: join(cwd, 'file'),
+    target: join(cwd, 'file', 'a.tsx'),
   });
   expect(existsSync(join(cwd, 'file', 'a.tsx'))).toEqual(true);
-  rimraf.sync(join(cwd, 'file'));
 });
 
 test('generate tpl by data', async () => {
@@ -45,5 +52,4 @@ test('generate tpl by data', async () => {
   expect(readFileSync(join(cwd, 'data', 'index.tsx'), 'utf-8')).toContain(
     'HomePage',
   );
-  rimraf.sync(join(cwd, 'data'));
 });

--- a/packages/utils/src/BaseGenerator/BaseGenerator.ts
+++ b/packages/utils/src/BaseGenerator/BaseGenerator.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, statSync } from 'fs';
-import { basename, dirname, join } from 'path';
+import { dirname } from 'path';
 import fsExtra from '../../compiled/fs-extra';
 import prompts from '../../compiled/prompts';
 import Generator from '../Generator/Generator';
@@ -18,7 +18,7 @@ export default class BaseGenerator extends Generator {
   questions: prompts.PromptObject[];
 
   constructor({ path, target, data, questions }: IOpts) {
-    super({ cwd: target, args: data });
+    super({ cwd: process.cwd(), args: data });
     this.path = path;
     this.target = target;
     this.data = data;
@@ -41,15 +41,14 @@ export default class BaseGenerator extends Generator {
         target: this.target,
       });
     } else {
-      const file = basename(this.path.replace(/\.tpl$/, ''));
       if (this.path.endsWith('.tpl')) {
         this.copyTpl({
           templatePath: this.path,
-          target: join(this.target, file),
+          target: this.target,
           context,
         });
       } else {
-        const absTarget = join(this.target, file);
+        const absTarget = this.target;
         fsExtra.mkdirpSync(dirname(absTarget));
         copyFileSync(this.path, absTarget);
       }


### PR DESCRIPTION
### nested  non dir mode

```bash
$npx umi g page  foo/bar
info  - @local
Write: pages/foo/bar.tsx
Write: pages/foo/bar.less
```

### nested with dir mode

```bash
$npx umi g page  xxx/yyy --dir
info  - @local
Write: pages/xxx/yyy/index.less
Write: pages/xxx/yyy/index.tsx
```
