### PR TITLE
fix(api-route): Fix bug of build platform and format

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
@@ -12,6 +12,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
 
   await esbuild.build({
     format: 'cjs',
+    platform: 'node',
     bundle: true,
     entryPoints: [
       ...apiRoutePaths,

--- a/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
@@ -18,8 +18,8 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
   );
 
   await esbuild.build({
-    format: 'esm',
-    outExtension: { '.js': '.mjs' },
+    format: 'cjs',
+    platform: 'node',
     bundle: true,
     entryPoints: [
       ...apiRoutePaths,


### PR DESCRIPTION
1. 修复了 API 路由打包时没有指定 `platform: 'node'` 导致部分依赖无法使用的问题
2. 修复了 API 路由的 Vercel Adpater 原本以 `esm` 格式打包导致部分不支持 `esm` 的依赖会报错的问题