### PR TITLE
fix(plugin-unocss): fix build don't exit

### DIFF
--- a/packages/plugins/src/unocss.ts
+++ b/packages/plugins/src/unocss.ts
@@ -1,8 +1,8 @@
 import { exec } from 'child_process';
-import * as fs from 'fs';
-import path from 'path';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { IApi } from 'umi';
-import { logger } from 'umi/plugin-utils';
+import { winPath } from 'umi/plugin-utils';
 
 export default (api: IApi) => {
   api.describe({
@@ -17,29 +17,35 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
+  const outputPath = 'uno.css';
+
   api.onStart(() => {
     /** 由于 @unocss/cli 对设置文件进行了检查，因此加入需要 unocss.config.ts 设置的提示
      * https://github.com/antfu/unocss/blob/main/packages/cli/src/index.ts#L93 */
-    if (!fs.existsSync(path.resolve(api.paths.cwd, 'unocss.config.ts')))
-      logger.warn(
+    if (!existsSync(join(api.paths.cwd, 'unocss.config.ts')))
+      api.logger.warn(
         '请在项目目录中添加 unocss.config.ts 文件，并配置需要的 unocss presets，否则插件将没有效果！',
       );
 
-    const generatedPath = path.resolve(api.paths.absTmpPath, 'uno.css');
-    const binPath = path.resolve(api.cwd, 'node_modules/.bin/unocss');
+    const generatedPath = join(api.paths.absTmpPath, outputPath);
+    const binPath = join(api.cwd, 'node_modules/.bin/unocss');
     const watchDirs = api.config.unocss.watch;
 
     /** 透过子进程建立 unocss 服务，将生成的 css 写入 generatedPath */
     const unocss = exec(
-      `${binPath} ${watchDirs.join(' ')} --out-file ${generatedPath} --watch`,
+      `${binPath} ${watchDirs.join(' ')} --out-file ${generatedPath} ${
+        api.env === 'development' ? '--watch' : ''
+      }`,
       { cwd: api.cwd },
     );
 
     unocss.on('error', (m: any) => {
       api.logger.error('unocss service encounter an error: ' + m);
     });
-
-    /** 将生成的 css 文件加入到 import 中 */
-    api.addEntryImports(() => [{ source: generatedPath }]);
+  });
+  /** 将生成的 css 文件加入到 import 中 */
+  api.addEntryImports(() => {
+    const generatedPath = winPath(join(api.paths.absTmpPath, outputPath));
+    return [{ source: generatedPath }];
   });
 };


### PR DESCRIPTION
修复build不会退出的情况，只有在 dev 下才开启 watch
@unocss/cli [generate](https://github.com/unocss/unocss/blob/main/packages/cli/src/index.ts#L20) 不支持创建路径不存在的文件夹，outputPath 中 暂时没有加 plugin-unocss