### PR TITLE
ci: only run on `master` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ env:
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'examples/**'
       - 'docs/**'


### PR DESCRIPTION
没限制 push 的 ci 分支，PR 里双倍的跑，头要炸了

现在三种时候会跑 ci ：

1. commit 到了主分支 `master` 会跑 ci

2. PR 的时候会跑，在任意仓库提过来的 PR 都会跑

3. fork 的仓库的默认分支可以手动跑 ci （一般情况是 master，如果不是，就切成默认分支，就可以手动运行）