### PR TITLE
fix(api-route): Fix bugs of Vercel adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /examples/*/.umi
 /examples/*/.umi-production
 /examples/*/.output
+/examples/*/api
 /examples/*/.umi-test
 /examples/*/src/.umi
 /examples/*/src/.umi-production

--- a/packages/preset-umi/src/features/apiRoute/constants.ts
+++ b/packages/preset-umi/src/features/apiRoute/constants.ts
@@ -1,1 +1,1 @@
-export const OUTPUT_PATH = '.output/server/pages/api';
+export const OUTPUT_PATH = 'api';

--- a/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
@@ -1,9 +1,9 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import fs from 'fs';
 import { join, resolve } from 'path';
 import type { IApi, IRoute } from '../../../types';
-import { esbuildIgnorePathPrefixPlugin } from '../utils';
-import fs from 'fs';
 import { OUTPUT_PATH } from '../constants';
+import { esbuildIgnorePathPrefixPlugin } from '../utils';
 
 interface VercelDynamicRouteConfig {
   page: string;
@@ -18,6 +18,8 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
     join(api.paths.absTmpPath, 'api', r.file),
   );
 
+  const pkg = require(join(api.cwd, './package.json'));
+
   await esbuild.build({
     format: 'cjs',
     platform: 'node',
@@ -28,6 +30,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
     ],
     outdir: resolve(api.paths.cwd, OUTPUT_PATH),
     plugins: [esbuildIgnorePathPrefixPlugin()],
+    external: [...Object.keys(pkg.dependencies || {})],
   });
 
   const dynamicRoutes: VercelDynamicRouteConfig[] = [];

--- a/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
@@ -1,16 +1,8 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
-import fs from 'fs';
 import { join, resolve } from 'path';
 import type { IApi, IRoute } from '../../../types';
 import { OUTPUT_PATH } from '../constants';
 import { esbuildIgnorePathPrefixPlugin } from '../utils';
-
-interface VercelDynamicRouteConfig {
-  page: string;
-  regex: string;
-  routeKeys: { [key: string]: string };
-  namedRegex: string;
-}
 
 // 将 API 路由的临时文件打包为 Vercel 的 Serverless Function 可以使用的格式
 export default async function (api: IApi, apiRoutes: IRoute[]) {
@@ -32,61 +24,4 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
     plugins: [esbuildIgnorePathPrefixPlugin()],
     external: [...Object.keys(pkg.dependencies || {})],
   });
-
-  const dynamicRoutes: VercelDynamicRouteConfig[] = [];
-
-  apiRoutes.map((r) => {
-    if (r.path.match(/\[.*]/)) {
-      const keys = r.path
-        .match(/\[.*?]/g)
-        ?.map((k) => (k = k.replace(/[\[\]]/g, '')));
-      const routeKeys: { [key: string]: string } = {};
-      keys?.map((k) => {
-        routeKeys[k] = k;
-      });
-      dynamicRoutes.push({
-        page: '/api/' + r.path,
-        regex: getVercelDynamicRoutesRegex(r.path),
-        routeKeys,
-        namedRegex: getVercelDynamicRoutesNamedRegex(r.path),
-      });
-    }
-  });
-
-  fs.writeFileSync(
-    join(api.paths.cwd, '.output/routes-manifest.json'),
-    JSON.stringify({ version: 3, dynamicRoutes }, null, 2),
-  );
-}
-
-/**
- *  按照 Vercel 的要求将动态路由进行转换
- *
- *  若传入的 path 是
- *  `/users/[userId]/repos/[repoId]`
- *
- *  则返回的 regex 为：
- *  `^/api/users/([^/]+?)/repos/([^/]+?)(?:/)?$`
- *
- *  这个 regex 是给 Vercel 用于匹配 Serverless functions 请求的
- *  参考：https://vercel.com/docs/file-system-api#configuration/routes
- */
-function getVercelDynamicRoutesRegex(path: string) {
-  return '^/api/' + path.replace(/\[.*?]/g, '([^/]+?)') + '(?:/)?$';
-}
-
-/**
- *  按照 Vercel 的要求将动态路由进行转换，并且将匹配组加入别名
- *
- *  若传入的 path 是
- *  `/users/[userId]/repos/[repoId]`
- *
- *  则返回的 regex 为：
- *  `^/api/users/(?<userId>[^/]+?)/repos/(?<repoId>[^/]+?)(?:/)?$`
- *
- *  这个 regex 是给 Vercel 用于匹配 Serverless functions 请求的
- *  参考：https://vercel.com/docs/file-system-api#configuration/routes
- */
-function getVercelDynamicRoutesNamedRegex(path: string) {
-  return '^/api/' + path.replace(/\[(.*?)]/g, '(?<$1>[^/]+?)') + '(?:/)?$';
 }


### PR DESCRIPTION
这几天在开发及部署 [umijs/umi-blog-example](https://github.com/umijs/umi-blog-example) 到 [Vercel](https://vercel.com/dashboard) 时发现了 API 路由功能还存在许多问题，距离投入生产还有一段距离，目前正在努力修复中，这个 PR 修复了两个已经找到的问题：

### 1. 将 API 路由编译产物的导出目录从 `.output/server/pages/api` 改为 `api`

也就是说，虽然启用了 Vercel 的 [File System API](https://vercel.com/docs/file-system-api)，但我们不自己生成最终产物 (`.output`)，而是在 `umi build` 过程中才生成 `api` 目录，然后因为开启了 File System API ，所以 Vercel 还是会帮忙把这个产物编译到 `.output` 中。

### 2. 不打包 `node_modules` 内的依赖到每个 API 路由的入口

在开发 [umijs/umi-blog-example](https://github.com/umijs/umi-blog-example) 时因为用了 [Prisma](https://www.prisma.io/) 作为 ORM，发现这个包会在运行时读取自己目录下的文件，而因为他的代码被我们打包起来了，所以这个文件自然就找不到了 ...

现在我们不打包这些依赖，Vercel 会帮我们在 Serverless function 运行时放到他的 `node_modules` 里面。