### PR TITLE
fix(bundler-vite): scripts not found in dist

### DIFF
--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "compiled",
-    "dist"
+    "dist",
+    "scripts"
   ],
   "scripts": {
     "build": "pnpm tsc",


### PR DESCRIPTION
## Description

修复 bundler-vite scripts 没发布到 NPM，导致 postinstall 脚本执行失败的问题