### PR TITLE
修复 umi  g  page 在交互模式下生成页面的bug

### DIFF
--- a/packages/preset-umi/src/commands/generators/page.test.ts
+++ b/packages/preset-umi/src/commands/generators/page.test.ts
@@ -127,3 +127,74 @@ describe('page generator', function () {
     }
   }
 });
+
+describe('page generate in interactive way', function () {
+  it('generate index page when no answer', async () => {
+    const generateFile = jest.fn().mockResolvedValue(null);
+    const prompts = jest.fn();
+
+    const g = new PageGenerator({
+      absPagesPath: '/pages/',
+      args: { _: [] },
+      generateFile,
+    });
+
+    g.setPrompter(prompts as any);
+    prompts.mockResolvedValueOnce({ name: '' });
+    prompts.mockResolvedValueOnce({ mode: 'file' });
+
+    await g.run();
+
+    expect(g.getDirMode()).toEqual(false);
+    expect(prompts).toBeCalledTimes(2);
+    expect(prompts).toHaveBeenNthCalledWith(1, {
+      type: 'text',
+      name: 'name',
+      message: 'What is the name of page?',
+    });
+    expect(prompts).toHaveBeenNthCalledWith(2, {
+      type: 'select',
+      name: 'mode',
+      message: 'How dou you want page files to be created?',
+      choices: [
+        { title: normalize('index/index.{tsx,less}'), value: 'dir' },
+        { title: normalize('index.{tsx,less}'), value: 'file' },
+      ],
+      initial: 0,
+    });
+  });
+
+  it('generate index page when answer file name', async () => {
+    const generateFile = jest.fn().mockResolvedValue(null);
+    const prompts = jest.fn();
+    const g = new PageGenerator({
+      absPagesPath: '/pages/',
+      args: { _: [] },
+      generateFile,
+    });
+
+    g.setPrompter(prompts as any);
+    prompts.mockResolvedValueOnce({ name: 'aaa/bbb' });
+    prompts.mockResolvedValueOnce({ mode: 'dir' });
+
+    await g.run();
+
+    expect(g.getDirMode()).toEqual(true);
+    expect(prompts).toBeCalledTimes(2);
+    expect(prompts).toHaveBeenNthCalledWith(1, {
+      type: 'text',
+      name: 'name',
+      message: 'What is the name of page?',
+    });
+    expect(prompts).toHaveBeenNthCalledWith(2, {
+      type: 'select',
+      name: 'mode',
+      message: 'How dou you want page files to be created?',
+      choices: [
+        { title: normalize('aaa/bbb/index.{tsx,less}'), value: 'dir' },
+        { title: normalize('aaa/bbb.{tsx,less}'), value: 'file' },
+      ],
+      initial: 0,
+    });
+  });
+});

--- a/packages/preset-umi/src/commands/generators/page.ts
+++ b/packages/preset-umi/src/commands/generators/page.ts
@@ -36,6 +36,8 @@ export class PageGenerator {
   private isDirMode = false;
   private dir = '';
   private name = '';
+  private needEnsureDirMode = false;
+  private prompts = prompts;
 
   constructor(
     readonly options: {
@@ -55,17 +57,28 @@ export class PageGenerator {
     const [_, nameOrPath = ''] = options.args._;
     if (nameOrPath) {
       this.setPath(nameOrPath);
+    } else {
+      this.needEnsureDirMode = true;
     }
   }
 
   async run() {
     await this.ensureName();
+    await this.ensureDirMode();
 
     if (this.isDirMode) {
       await this.dirModeRun();
     } else {
       await this.fileModeRun();
     }
+  }
+
+  setPrompter(p: typeof prompts) {
+    this.prompts = p;
+  }
+
+  getDirMode() {
+    return this.isDirMode;
   }
 
   private setPath(np: string) {
@@ -79,15 +92,44 @@ export class PageGenerator {
       return;
     }
 
-    const response = await prompts({
+    const response = await this.prompts({
       type: 'text',
       name: 'name',
       message: 'What is the name of page?',
     });
-    if (!response.name) {
-      this.name = response.name || 'index';
-      this.isDirMode = false;
+    if (response.name) {
+      this.setPath(response.name);
+    } else {
+      this.setPath('index');
     }
+    this.isDirMode = false;
+  }
+
+  private async ensureDirMode() {
+    if (!this.needEnsureDirMode) return;
+
+    const response = await this.prompts({
+      type: 'select',
+      name: 'mode',
+      message: 'How dou you want page files to be created?',
+      choices: [
+        { title: this.dirModeFileExample(), value: 'dir' },
+        { title: this.fileModeFileExample(), value: 'file' },
+      ],
+      initial: 0,
+    });
+
+    this.isDirMode = response.mode === 'dir';
+  }
+
+  private fileModeFileExample() {
+    const base = join(this.dir, this.name);
+    return `${base}.{tsx,less}`;
+  }
+
+  private dirModeFileExample() {
+    const base = join(this.dir, this.name, 'index');
+    return `${base}.{tsx,less}`;
   }
 
   private async fileModeRun() {


### PR DESCRIPTION
fix: 通过 prompts 获取 page name 之后未 调用 setPath 导致 page 文件名未分析和路径错误
feat: 增加通过 prompts 让用户选择 是否 `--dir` 
test: 增加对应测试