### PR TITLE
performace improve for umi cli

### DIFF
--- a/packages/core/src/service/plugin.ts
+++ b/packages/core/src/service/plugin.ts
@@ -77,8 +77,9 @@ export class Plugin {
         throw new Error(
           `Register ${this.type} ${this.path} failed, since ${e.message}`,
         );
+      } finally {
+        register.restore();
       }
-      register.restore();
       // use the default member for es modules
       return ret.__esModule ? ret.default : ret;
     };
@@ -118,6 +119,7 @@ export class Plugin {
         .map((part) => lodash.camelCase(part))
         .join('.');
     }
+
     return nameToKey(
       opts.isPkgEntry
         ? Plugin.stripNoneUmiScope(opts.pkg.name).replace(RE[this.type], '')
@@ -181,6 +183,7 @@ export class Plugin {
         });
       });
     }
+
     return {
       presets: get('preset'),
       plugins: get('plugin'),

--- a/packages/core/src/service/plugin.ts
+++ b/packages/core/src/service/plugin.ts
@@ -78,9 +78,6 @@ export class Plugin {
           `Register ${this.type} ${this.path} failed, since ${e.message}`,
         );
       }
-      for (const file of register.getFiles()) {
-        delete require.cache[file];
-      }
       register.restore();
       // use the default member for es modules
       return ret.__esModule ? ret.default : ret;

--- a/packages/core/src/service/plugin.ts
+++ b/packages/core/src/service/plugin.ts
@@ -68,6 +68,7 @@ export class Plugin {
     this.apply = () => {
       register.register({
         implementor: esbuild,
+        exts: ['.ts', '.mjs'],
       });
       register.clearFiles();
       let ret;

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -39,6 +39,9 @@
     "@umijs/test": "4.0.0-canary.20220317.2",
     "@umijs/utils": "4.0.0-canary.20220317.2"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/src/register.ts
+++ b/packages/utils/src/register.ts
@@ -12,24 +12,21 @@ function transform(opts: { code: string; filename: string; implementor: any }) {
   const { code, filename, implementor } = opts;
   files.push(filename);
   const ext = extname(filename);
-  if (COMPILE_EXTS.includes(ext)) {
-    return implementor.transformSync(code, {
-      loader: ext.slice(1),
-      target: 'es2017',
-      format: 'cjs',
-    }).code;
-  }
-  return code;
+  return implementor.transformSync(code, {
+    loader: ext.slice(1),
+    target: 'es2017',
+    format: 'cjs',
+  }).code;
 }
 
-export function register(opts: { implementor: any }) {
+export function register(opts: { implementor: any; exts?: string[] }) {
   files = [];
   if (!registered) {
     revert = addHook(
       (code, filename) =>
         transform({ code, filename, implementor: opts.implementor }),
       {
-        ext: HOOK_EXTS,
+        ext: opts.exts || HOOK_EXTS,
         ignoreNodeModules: true,
       },
     );


### PR DESCRIPTION
for issue  #504 

1. umi `engins.node`  >= 14 进 `package.json` js 直接写插件的不会因为 es 问题，导致无法执行。（参考  https://node.green/
2. 改进 register 移除没有必要的`includes`判断，pirates 已经会ext分发
3. 支持指定 ext 是否需要transform
4. 保留 require.cache

```
$time  node   /Users/pshu/git/umi-next/packages/umi/bin/umi.js  g page test/test --dir
info  - @local
Write: index.less
Write: index.tsx

real	0m1.150s
user	0m1.057s
sys	0m0.165s
```