### PR TITLE
fix(bundler-vite): install failed bug with yarn

### DIFF
--- a/packages/bundler-vite/scripts/linkDeps.js
+++ b/packages/bundler-vite/scripts/linkDeps.js
@@ -2,8 +2,15 @@
 const fs = require('fs');
 const path = require('path');
 const target = path.dirname(require.resolve('@umijs/bundler-utils/compiled/less/package.json'));
-const symlink = path.join(__dirname, '../node_modules/less');
+const installDir = path.join(__dirname, '../node_modules');
+const symlink = path.join(installDir, 'less');
 const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
 
-if (fs.existsSync(symlink)) fs.unlinkSync(symlink);
+if (fs.existsSync(symlink)) {
+  // for multi-times install, in dev
+  fs.unlinkSync(symlink);
+} else if (!fs.existsSync(installDir)) {
+  // for yarn-like install, no node_modules dir
+  fs.mkdirSync(installDir);
+}
 fs.symlinkSync(target, symlink, symlinkType);


### PR DESCRIPTION
## Description

修复 yarn 安装时 bundler-vite 的 postinstall 脚本执行失败的问题