### PR TITLE
fix(api-route-types): Fix types of api route exported from preset-umi

### DIFF
--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -1,3 +1,4 @@
+export type { UmiApiRequest, UmiApiResponse } from './features/apiRoute';
 export type { IApi, IConfig, webpack } from './types';
 export default () => {
   return {

--- a/packages/umi/index.d.ts
+++ b/packages/umi/index.d.ts
@@ -1,9 +1,10 @@
 // @ts-ignore
 export * from '@@/exports';
-export type { IApi, webpack } from '@umijs/preset-umi';
 export type {
+  IApi,
+  webpack,
   IRoute,
   UmiApiRequest,
   UmiApiResponse,
-} from '@umijs/preset-umi/src/types';
+} from '@umijs/preset-umi';
 export * from './dist';


### PR DESCRIPTION
# 当前问题

如果在项目中使用 `pnpm i umi` 然后使用 API 路由功能，无法透过

```ts
import { UmiApiRequest, UmiApiResponse } from "umi";
```

启用 Typescript 的类型支持。

<img width="677" alt="Screen Shot 2022-03-22 at 4 34 28 PM" src="https://user-images.githubusercontent.com/21105863/159439901-f5ff5501-a1ea-4912-8de5-81d9b638681e.png">

# 原因

使用 `import { UmiApiRequest, UmiApiResponse } from "umi";` 的时候，IDE 会去 `node_modules/umi/index.d.ts` 查找类型，但这个文件是这样写的：

```ts
export type {
  IRoute,
  UmiApiRequest,
  UmiApiResponse,
} from '@umijs/preset-umi/src/types';
```

可以看到我们要的类型是从 `@umijs/preset-umi/src/types` 导入的，但 `src` 目录并不会在 `pnpm i` 的时候下载下来。

# 解决方案

让这些类型透过 `@umijs/preset-umi` 导出，而不是从 `@umijs/preset-umi/src/types`