### PR TITLE
fix: missing dep and require abs path

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -36,6 +36,7 @@
     "@svgr/plugin-svgo": "^6.2.0",
     "@types/hapi__joi": "17.1.8",
     "@umijs/babel-preset-umi": "4.0.0-canary.20220325.1",
+    "@umijs/bundler-utils": "4.0.0-canary.20220325.1",
     "@umijs/mfsu": "4.0.0-canary.20220325.1",
     "@umijs/utils": "4.0.0-canary.20220325.1",
     "css-loader": "6.7.1",

--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -1,20 +1,19 @@
 import { getMarkup } from '@umijs/server';
-import { importLazy, logger } from '@umijs/utils';
+import { logger } from '@umijs/utils';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from '../types';
 import { clearTmp } from '../utils/clearTmp';
+import { lazyImportFromCurrentPkg } from '../utils/lazyImportFromCurrentPkg';
+import { getAssetsMap } from './dev/getAssetsMap';
 import { getBabelOpts } from './dev/getBabelOpts';
 import { getMarkupArgs } from './dev/getMarkupArgs';
 import { printMemoryUsage } from './dev/printMemoryUsage';
-import { getAssetsMap } from './dev/getAssetsMap';
 
-const bundlerWebpack: typeof import('@umijs/bundler-webpack') = importLazy(
-  '@umijs/bundler-webpack',
-);
-const bundlerVite: typeof import('@umijs/bundler-vite') = importLazy(
-  '@umijs/bundler-vite',
-);
+const bundlerWebpack: typeof import('@umijs/bundler-webpack') =
+  lazyImportFromCurrentPkg('@umijs/bundler-webpack');
+const bundlerVite: typeof import('@umijs/bundler-vite') =
+  lazyImportFromCurrentPkg('@umijs/bundler-vite');
 
 export default (api: IApi) => {
   api.registerCommand({

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -1,10 +1,11 @@
 import type { RequestHandler } from '@umijs/bundler-webpack';
-import { importLazy, lodash, logger, portfinder, winPath } from '@umijs/utils';
+import { lodash, logger, portfinder, winPath } from '@umijs/utils';
 import { readFileSync } from 'fs';
 import { basename, join } from 'path';
 import { DEFAULT_HOST, DEFAULT_PORT } from '../../constants';
 import { IApi } from '../../types';
 import { clearTmp } from '../../utils/clearTmp';
+import { lazyImportFromCurrentPkg } from '../../utils/lazyImportFromCurrentPkg';
 import { createRouteMiddleware } from './createRouteMiddleware';
 import { faviconMiddleware } from './faviconMiddleware';
 import { getBabelOpts } from './getBabelOpts';
@@ -17,12 +18,10 @@ import {
   watch,
 } from './watch';
 
-const bundlerWebpack: typeof import('@umijs/bundler-webpack') = importLazy(
-  '@umijs/bundler-webpack',
-);
-const bundlerVite: typeof import('@umijs/bundler-vite') = importLazy(
-  '@umijs/bundler-vite',
-);
+const bundlerWebpack: typeof import('@umijs/bundler-webpack') =
+  lazyImportFromCurrentPkg('@umijs/bundler-webpack');
+const bundlerVite: typeof import('@umijs/bundler-vite') =
+  lazyImportFromCurrentPkg('@umijs/bundler-vite');
 
 export default (api: IApi) => {
   api.describe({

--- a/packages/preset-umi/src/utils/lazyImportFromCurrentPkg.ts
+++ b/packages/preset-umi/src/utils/lazyImportFromCurrentPkg.ts
@@ -1,0 +1,9 @@
+import { importLazy } from '@umijs/utils';
+import { dirname } from 'path';
+
+/**
+ * lazy require dep from current package position (preset-umi)
+ */
+export const lazyImportFromCurrentPkg = (depName: string) => {
+  return importLazy(dirname(require.resolve(`${depName}/package.json`)));
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,7 @@ importers:
       '@types/webpack-sources': 3.2.0
       '@types/ws': 8.5.3
       '@umijs/babel-preset-umi': 4.0.0-canary.20220325.1
+      '@umijs/bundler-utils': 4.0.0-canary.20220325.1
       '@umijs/mfsu': 4.0.0-canary.20220325.1
       '@umijs/utils': 4.0.0-canary.20220325.1
       autoprefixer: 10.4.4
@@ -670,6 +671,7 @@ importers:
       '@svgr/plugin-svgo': 6.2.0_@svgr+core@6.2.1
       '@types/hapi__joi': 17.1.8
       '@umijs/babel-preset-umi': link:../babel-preset-umi
+      '@umijs/bundler-utils': link:../bundler-utils
       '@umijs/mfsu': link:../mfsu
       '@umijs/utils': link:../utils
       css-loader: 6.7.1_webpack@5.70.0


### PR DESCRIPTION

1. 用了，但是没把 `@umijs/bundler-utils` 放到生产依赖里。
2. require 的时候要走绝对路径，不然跑到其他地方了。

try resolve https://github.com/umijs/umi-next/issues/480
