### PR TITLE
chore:  avoid unreferenced 'React' errors-ts(2686)

### DIFF
--- a/packages/create-umi/templates/app/tsconfig.json
+++ b/packages/create-umi/templates/app/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "sourceMap": true,
     "baseUrl": ".",


### PR DESCRIPTION
`import React from 'react'` should not be mandatory.