### PR TITLE
test: boilerplate add e2e case

### DIFF
--- a/examples/boilerplate/__tests__/boilerplate.e2e.ts
+++ b/examples/boilerplate/__tests__/boilerplate.e2e.ts
@@ -1,0 +1,62 @@
+import { join } from 'path';
+import type { ConsoleMessage } from 'playwright-chromium';
+import { createServer, createUmi } from 'test-utils';
+
+jest.setTimeout(35 * 1000);
+
+let logs: string[] = [];
+
+const onConsole = (msg: ConsoleMessage) => {
+  logs.push(msg.text());
+};
+
+test('boilerplate e2e', async () => {
+  try {
+    page.on('console', onConsole);
+
+    const cwd = join(__dirname, '..');
+
+    const project = createUmi({
+      cwd,
+    });
+
+    const { stdout } = await project.run('pnpm', ['build']);
+
+    // build
+    expect(stdout).toMatch('Build index.html');
+    expect(project.has('dist/index.html')).toBe(true);
+    expect(project.has('dist/umi.js')).toBe(true);
+    expect(project.has('dist/umi.css')).toBe(true);
+
+    const server = createServer(project.projectRoot);
+
+    const url = await server.run();
+
+    await page.goto(url);
+
+    // console
+    const logsStr = logs.join('');
+
+    expect(logsStr).toMatch('head script');
+    expect(logsStr).toMatch('hello world from head');
+    expect(logsStr).toMatch('hello world');
+    expect(logsStr).toMatch('global.ts');
+    expect(logsStr).toMatch('entry code ahead');
+    expect(logsStr).toMatch('entry code');
+    expect(logsStr).toMatch('rerender layout');
+
+    // html
+    await expect(page).toMatchText(/Foo/);
+    await expect(page).toMatchText(/dataflowProvider/);
+    await expect(page).toMatchText(/innerProvider/);
+    await expect(page).toMatchText(/global layout/);
+    await expect(page).toMatchText(/HomePage/);
+
+    const element = await page.$('body');
+    await expect(element).toMatchComputedStyle('color', 'rgb(255, 0, 0)');
+    await server.close();
+  } finally {
+    page.off('console', onConsole);
+    logs = [];
+  }
+});

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "exclude": ["**/dist/**", "**/*.js"],
+  "include": ["."],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "jsx": "react",
+    "types": ["@types/jest", "jest-playwright-preset", "expect-playwright"],
+    "paths": {
+      "test-utils": ["../test/lib/testUtils.ts"]
+    }
+  }
+}

--- a/jest.e2e.config.ts
+++ b/jest.e2e.config.ts
@@ -3,7 +3,6 @@ import { Config, createConfig } from 'umi/test';
 export default {
   ...createConfig(),
   preset: 'jest-playwright-preset',
-  setupFilesAfterEnv: ['expect-playwright'],
   testMatch: ['**/*.e2e.ts'],
   modulePathIgnorePatterns: [
     '<rootDir>/packages/.+/compiled',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "regenerator-runtime": "^0.13.9",
     "resolve": "^1.22.0",
     "rimraf": "^3.0.2",
+    "sirv": "^2.0.2",
     "ts-node": "^10.7.0",
     "turbo": "^1.1.9",
     "typescript": "^4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ importers:
       regenerator-runtime: ^0.13.9
       resolve: ^1.22.0
       rimraf: ^3.0.2
+      sirv: ^2.0.2
       ts-node: ^10.7.0
       turbo: ^1.1.9
       typescript: ^4.6.2
@@ -79,6 +80,7 @@ importers:
       regenerator-runtime: 0.13.9
       resolve: 1.22.0
       rimraf: 3.0.2
+      sirv: 2.0.2
       ts-node: 10.7.0_5338de7ff0b33ef224ee85855d74b9f4
       turbo: 1.1.9
       typescript: 4.6.2
@@ -2228,7 +2230,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.3
       gensync: 1.0.0-beta.2
-      json5: 2.2.0
+      json5: 2.2.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -13911,7 +13913,6 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
@@ -19724,7 +19725,6 @@ packages:
       '@polka/url': 1.0.0-next.21
       mrmime: 1.0.0
       totalist: 3.0.0
-    dev: false
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -20897,7 +20897,6 @@ packages:
   /totalist/3.0.0:
     resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
     engines: {node: '>=6'}
-    dev: false
 
   /tough-cookie/2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}


### PR DESCRIPTION
给 examples/boilerplate 增加e2e

## 改动点

- `test-utils` 新增 `run` 用于执行代码构建
- `test-utils` 新增 `createServer` 用于服务启动
- examples 新增 `tsconfig.json` 注入e2e ts 声明相关
-  examples/boilerplate 新增`__tests__/boilerplate.e2e.ts` 完成一部分case 的编写 详见用例