### PR TITLE
优化 beforeMiddleware 的定义方式

### DIFF
--- a/docs/docs/guides/env-variables.md
+++ b/docs/docs/guides/env-variables.md
@@ -1,1 +1,10 @@
 # 环境变量
+
+
+## DEVTOOL_LOCAL
+
+使用方法
+```shell
+DEVTOOL_LOCAL=1 umi dev 
+```
+在项目中开启 umi 开发者工具, 工具默认路径为`http://127.0.0.1:8000/__umi` 

--- a/packages/bundler-vite/src/server/server.ts
+++ b/packages/bundler-vite/src/server/server.ts
@@ -1,5 +1,5 @@
 import express from '@umijs/bundler-utils/compiled/express';
-import { logger } from '@umijs/utils';
+import { logger, mountMiddleware } from '@umijs/utils';
 import http from 'http';
 import type {
   DepOptimizationMetadata,
@@ -58,7 +58,7 @@ export async function createServer(opts: IOpts) {
   });
 
   // before middlewares
-  opts.beforeMiddlewares?.forEach((m) => app.use(m));
+  opts.beforeMiddlewares?.forEach((m) => mountMiddleware(app, m));
 
   // after middlewares, insert before vite spaFallbackMiddleware
   // refer: https://github.com/vitejs/vite/blob/2c586165d7bc4b60f8bcf1f3b462b97a72cce58c/packages/vite/src/node/server/index.ts#L508

--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -3,7 +3,7 @@ import { createProxyMiddleware } from '@umijs/bundler-webpack/compiled/http-prox
 import webpack, {
   Configuration,
 } from '@umijs/bundler-webpack/compiled/webpack';
-import { chalk, logger } from '@umijs/utils';
+import { chalk, logger, mountMiddleware } from '@umijs/utils';
 import { createReadStream, existsSync } from 'fs';
 import http from 'http';
 import { join } from 'path';
@@ -62,7 +62,7 @@ export async function createServer(opts: IOpts) {
   // TODO: headers
 
   // before middlewares
-  (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
+  opts.beforeMiddlewares?.forEach((m) => mountMiddleware(app, m));
 
   // TODO: add to before middleware
   app.use((req, res, next) => {

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -11,6 +11,7 @@ import type {
   PluginAPI,
 } from '@umijs/core';
 import { Env } from '@umijs/core';
+import type { MiddleWare } from '@umijs/utils';
 import type { CheerioAPI } from '@umijs/utils/compiled/cheerio';
 import type { InlineConfig as ViteInlineConfig } from 'vite';
 
@@ -70,7 +71,7 @@ export type IApi = PluginAPI &
     addApiMiddlewares: IAdd<null, IApiMiddleware>;
     addBeforeBabelPlugins: IAdd<null, any>;
     addBeforeBabelPresets: IAdd<null, any>;
-    addBeforeMiddlewares: IAdd<null, RequestHandler>;
+    addBeforeMiddlewares: IAdd<null, MiddleWare>;
     addEntryCode: IAdd<null, string>;
     addEntryCodeAhead: IAdd<null, string>;
     addEntryImports: IAdd<null, IEntryImport>;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,6 +27,7 @@
     "@types/color": "3.0.3",
     "@types/cross-spawn": "6.0.2",
     "@types/debug": "4.1.7",
+    "@types/express": "^4.17.13",
     "@types/lodash": "4.14.180",
     "@types/mustache": "4.1.2",
     "@types/prompts": "^2.0.14",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -25,9 +25,11 @@ import Generator from './Generator/Generator';
 import installDeps from './installDeps';
 import * as logger from './logger';
 import updatePackageJSON from './updatePackageJSON';
+
 export * from './getCorejsVersion';
 export * from './importLazy';
 export * from './isStyleFile';
+export * from './middlewareUtils';
 export * from './npmClient';
 export * from './randomColor/randomColor';
 export * as register from './register';

--- a/packages/utils/src/middlewareUtils.ts
+++ b/packages/utils/src/middlewareUtils.ts
@@ -1,0 +1,69 @@
+import { isArray, isFunction } from '@umijs/utils/compiled/lodash';
+import type { Application, Request, RequestHandler, Response } from 'express';
+import { existsSync } from 'fs';
+import { join, resolve } from 'path';
+
+export function serveUmiApp(root: string) {
+  const resolvedRoot = resolve(root);
+
+  const index = join(resolvedRoot, 'index.html');
+
+  return function (req: Request, res: Response) {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.status(405);
+      res.setHeader('Allow', 'GET, HEAD');
+      res.setHeader('Content-Length', '0');
+      res.end();
+      return;
+    }
+    const file = join(resolvedRoot, req.path);
+
+    if (existsSync(file)) {
+      res.sendFile(file);
+    } else {
+      res.sendFile(index);
+    }
+  };
+}
+
+// just a subset of all supported methods of express
+type HttpMethod = 'get' | 'post' | 'head' | 'put';
+
+type MiddlewareDesc = {
+  handler: RequestHandler | RequestHandler[];
+  method?: HttpMethod[] | HttpMethod;
+  path?: string;
+};
+
+function isMiddlewareDesc(md: any): md is MiddlewareDesc {
+  return isFunction(md.handler) || isArray(md.handler);
+}
+
+export type MiddleWare = RequestHandler | MiddlewareDesc;
+
+export function mountMiddleware(app: Application, mw: MiddleWare) {
+  if (typeof mw === 'function') {
+    app.use(mw);
+    return;
+  }
+  if (isMiddlewareDesc(mw)) {
+    const path = mw.path || '/';
+    const handler = isArray(mw.handler) ? mw.handler : [mw.handler];
+
+    if (mw.method) {
+      if (isArray(mw.method)) {
+        if (mw.method.length) {
+          mw.method.forEach((m) => {
+            app[m](path, ...handler);
+          });
+        } else {
+          app.use(path, ...handler);
+        }
+      } else {
+        app[mw.method](path, ...handler);
+      }
+    } else {
+      app.use(path, ...handler);
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,7 @@ importers:
       '@types/color': 3.0.3
       '@types/cross-spawn': 6.0.2
       '@types/debug': 4.1.7
+      '@types/express': ^4.17.13
       '@types/lodash': 4.14.180
       '@types/mustache': 4.1.2
       '@types/prompts': ^2.0.14
@@ -1025,6 +1026,7 @@ importers:
       '@types/color': 3.0.3
       '@types/cross-spawn': 6.0.2
       '@types/debug': 4.1.7
+      '@types/express': 4.17.13
       '@types/lodash': 4.14.180
       '@types/mustache': 4.1.2
       '@types/prompts': 2.0.14
@@ -6958,7 +6960,7 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 17.0.21
+      '@types/node': 17.0.22
 
   /@types/sockjs/0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}


### PR DESCRIPTION
支持安装 expres middleware 时，指定 method 和 path 简化 middleware 函数的定义
好处：

* 能更好地利用 express middleware 生态
* 通过 path 的限定可以不用 next 到其他无关的 middleware 上去


目前 aftermiddleware 没有修改，因为 bundler-webpack 里面有段神奇的代码，暂时不能用统一的方式来安装，之后再想想怎么解决

```
  // after middlewares
  (opts.afterMiddlewares || []).forEach((m) => {
    // TODO: FIXME
    app.use(m.toString().includes(`{ compiler }`) ? m({ compiler }) : m);
  });
```