### PR TITLE
fix: 🐛 移除 convention 方式生成的 _middlewares 的路由

### DIFF
--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -17,6 +17,8 @@ export default (api: IApi) => {
     memo.apiRoutes = await getApiRoutes({
       api,
     });
+    delete memo.apiRoutes['_middlewares'];
+
     memo.hasSrcDir = api.paths.absSrcPath.endsWith('/src');
     memo.npmClient = api.userConfig.npmClient || getNpmClient();
     memo.umi = {


### PR DESCRIPTION
Close #564 