### PR TITLE
fix(api-route): Fix bug of api route that overwrite `cwd.api` directory

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/constants.ts
+++ b/packages/preset-umi/src/features/apiRoute/constants.ts
@@ -1,1 +1,34 @@
-export const OUTPUT_PATH = 'api';
+import { join } from 'path';
+import type { IApi } from '../../types';
+
+export enum ServerlessPlatform {
+  Vercel = 'vercel',
+  Netlify = 'netlify',
+  Worker = 'worker',
+  UmiDevServer = 'umi-dev-server',
+}
+
+export function getPlatform(p: string) {
+  switch (p) {
+    case 'vercel':
+      return ServerlessPlatform.Vercel;
+    case 'netlify':
+      return ServerlessPlatform.Netlify;
+    case 'worker':
+      return ServerlessPlatform.Worker;
+    default:
+      return undefined;
+  }
+}
+
+// Get the final output path of the api route files
+export function getApiRouteBuildPath(api: IApi, platform: ServerlessPlatform) {
+  switch (platform) {
+    case ServerlessPlatform.Vercel:
+      return join(api.paths.cwd, 'api');
+    case ServerlessPlatform.UmiDevServer:
+      return join(api.paths.absTmpPath, 'api/_compiled');
+    default:
+      return join(api.paths.cwd, 'api');
+  }
+}

--- a/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
@@ -1,7 +1,7 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
 import { join, resolve } from 'path';
 import type { IApi, IRoute } from '../../../types';
-import { OUTPUT_PATH } from '../constants';
+import { getApiRouteBuildPath, ServerlessPlatform } from '../constants';
 import { esbuildIgnorePathPrefixPlugin } from '../utils';
 
 // 将 API 路由的临时文件打包为 Vercel 的 Serverless Function 可以使用的格式
@@ -20,7 +20,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
       ...apiRoutePaths,
       resolve(api.paths.absTmpPath, 'api/_middlewares.ts'),
     ],
-    outdir: resolve(api.paths.cwd, OUTPUT_PATH),
+    outdir: getApiRouteBuildPath(api, ServerlessPlatform.Vercel),
     plugins: [esbuildIgnorePathPrefixPlugin()],
     external: [...Object.keys(pkg.dependencies || {})],
   });


### PR DESCRIPTION
# 问题

如果用户的项目结构没有用 `src` 目录将源代码包起来，直接在 `cwd.api` 目录使用 API 路由的功能的话，API 路由的构建产物会和源代码目录冲突。

# 修复方案

这个 PR 将 `umi dev` 时的 API 路由构建产物从 `cwd.api` 移至 `.umi/api/_compile` 临时目录内，因此源代码不会被覆盖掉。

# 备注

将构建产物放置于 `cwd.api` 是 [Vercel 的约定](https://vercel.com/docs/concepts/functions/serverless-functions#path-segments)，因此若用户想要把 API 路由的功能部署到 Vercel 平台，唯一的解决方案是修改目录结构，将源代码放到 `src` 目录下。