### PR TITLE
fix(api-route): Fix #566 api route match behavior

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/utils.ts
+++ b/packages/preset-umi/src/features/apiRoute/utils.ts
@@ -42,7 +42,20 @@ export function matchApiRoute(
 
   const params: { [key: string]: string } = {};
 
-  const route = apiRoutes.find((route) => {
+  // Sort routes by path length, so we can match the longest route first
+  // If two routes have the same length, we'll match the one who has dynamic segments first
+  const sorted = apiRoutes.sort((a, b) => {
+    const aSegments = a.path.split('/').filter((p) => p !== '');
+    const bSegments = b.path.split('/').filter((p) => p !== '');
+    if (aSegments.length !== bSegments.length) {
+      return aSegments.length - bSegments.length;
+    }
+    const aDynamicIndex = aSegments.findIndex((p) => p.match(/^\[.*]$/));
+    const bDynamicIndex = bSegments.findIndex((p) => p.match(/^\[.*]$/));
+    return aDynamicIndex - bDynamicIndex;
+  });
+
+  const route = sorted.find((route) => {
     const routePathSegments = route.path.split('/').filter((p) => p !== '');
 
     if (routePathSegments.length !== pathSegments.length) return false;


### PR DESCRIPTION
修复了 #566 API 路由功能在匹配路由时行为不一致的问题。

解决方案是在 match 前对路由进行排序，优先匹配较长的路由。

对于长度相同的路由，优先匹配静态路由而不是动态路由。

example:

假设我们有以下路由

```
/api/users/[id]
/api/users/banana
/api/users/[id]/apple
/api/users/[id]/[repo]
```

则排序结果应该是

```
/api/users/[id]/apple
/api/users/[id]/[repo]
/api/users/banana
/api/users/[id]
```

然后自上而下匹配当前请求路径，找到应该给哪个 API 路由处理
