### PR TITLE
feat(lowImport): support disable lowImport.css

### DIFF
--- a/packages/preset-umi/src/features/lowImport/babelPlugin.test.ts
+++ b/packages/preset-umi/src/features/lowImport/babelPlugin.test.ts
@@ -4,7 +4,7 @@ interface IOpts {
   code: string;
   filename?: string;
   opts?: any;
-  css?: string;
+  css?: string | boolean;
   umiImportItems?: string[];
   reactImportItems?: string[];
 }
@@ -17,7 +17,7 @@ function doTransform(opts: IOpts): string {
         require.resolve('./babelPlugin.ts'),
         {
           opts: opts.opts?.opts,
-          css: opts.css || 'less',
+          css: opts.css === false ? opts.css : opts.css || 'less',
           umiImportItems: opts.umiImportItems,
           reactImportItems: opts.reactImportItems,
         },
@@ -192,6 +192,19 @@ test('import styles css', () => {
       css: 'css',
     }),
   ).toEqual(`import _styles from "./index.css";\n_styles.btn;`);
+});
+
+test('disable styles css', () => {
+  expect(
+    doTransform({
+      code: `styles.btn`,
+      opts: {
+        opts: { withObjs: {} },
+      },
+      filename: 'index.tsx',
+      css: false,
+    }),
+  ).toEqual(`styles.btn;`);
 });
 
 test('import umi', () => {

--- a/packages/preset-umi/src/features/lowImport/lowImport.ts
+++ b/packages/preset-umi/src/features/lowImport/lowImport.ts
@@ -76,7 +76,7 @@ export default (api: IApi) => {
       schema(Joi) {
         return Joi.object({
           libs: Joi.array(),
-          css: Joi.string(),
+          css: [Joi.string(), Joi.boolean()],
         });
       },
     },
@@ -128,6 +128,8 @@ export default (api: IApi) => {
       .map((item) => `const ${item}: typeof import('react')['${item}']`)
       .join('\n');
 
+    const css = api.config.lowImport?.css;
+
     // TODO: styles 的类型提示
     const content =
       `
@@ -135,7 +137,7 @@ export default (api: IApi) => {
 declare global {
 const React: typeof import('react');
 ${dts.join('\n')}
-const styles: any;
+${css === false ? '' : `const styles: any;`}
 ${umiDts}
 ${reactDts}
 }
@@ -146,7 +148,8 @@ export {}
 
   api.addBeforeBabelPresets(() => {
     const opts = normalizeLibs(api.appData.lowImport);
-    const css = api.config.lowImport?.css || 'less';
+    const cssCfg = api.config.lowImport?.css;
+    const css = cssCfg === false ? cssCfg : cssCfg || 'less';
     return [
       {
         plugins: [


### PR DESCRIPTION
FIX ISSUE https://github.com/umijs/umi-next/issues/577

某些场景比如使用 https://vanilla-extract.style/documentation 作为 css in js 方案时，希望保留 ts 的校验/提示能力，此时需要将 lowImport.css 设置为 false