### PR TITLE
🐛  fix file reslove in module with exports definition

### DIFF
--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -11,9 +11,8 @@ import { getExposeFromContent } from './getExposeFromContent';
 const resolver = enhancedResolve.create({
   mainFields: ['module', 'browser', 'main'], // es module first
   extensions: ['.js', '.json', '.mjs'],
-  // TODO: support exports
-  // tried to add exports, but it don't work with swr
-  exportsFields: [],
+  exportsFields: ['exports'],
+  conditionNames: ['import', 'module', 'require'],
 });
 
 async function resolve(context: string, path: string): Promise<string> {
@@ -32,6 +31,7 @@ export class Dep {
   public normalizedFile: string;
   public filePath: string;
   public mfsu: MFSU;
+
   constructor(opts: {
     file: string;
     version: string;
@@ -68,6 +68,7 @@ export * from '${this.file}';
 
     // none node natives
     const realFile = await this.getRealFile();
+    console.log('xxxx ->', this.file, realFile);
     assert(realFile, `filePath not found of ${this.file}`);
     const content = readFileSync(realFile, 'utf-8');
     return await getExposeFromContent({

--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -12,7 +12,7 @@ const resolver = enhancedResolve.create({
   mainFields: ['module', 'browser', 'main'], // es module first
   extensions: ['.js', '.json', '.mjs'],
   exportsFields: ['exports'],
-  conditionNames: ['import', 'module', 'require'],
+  conditionNames: ['import', 'module', 'require', 'node'],
 });
 
 async function resolve(context: string, path: string): Promise<string> {
@@ -68,7 +68,6 @@ export * from '${this.file}';
 
     // none node natives
     const realFile = await this.getRealFile();
-    console.log('xxxx ->', this.file, realFile);
     assert(realFile, `filePath not found of ${this.file}`);
     const content = readFileSync(realFile, 'utf-8');
     return await getExposeFromContent({


### PR DESCRIPTION
`swiper/react` 不能使用的错误是因为无法解析到正确的文件地址，只要添加 enhanced-resolve `exportsFields: ['exports'], ` 即可修复，

`swr` 开启 exportsFields 之后，无法解析路径，是因为没有配置对应的 conditionNames，配置之后就可以使用了。
至于配置的 conditonName 的放置的位置没有必要纠结。
参考  https://github.com/webpack/enhanced-resolve/issues/318#issuecomment-1055518577 
和
https://github.com/webpack/enhanced-resolve/blob/c960801d5cfbb6a472e40a7fe8f6c0679955a13b/lib/util/entrypoints.js#L470 （conditonNames 只是 resolve 是否可以使用的集合）


