### PR TITLE
cerate-umi 和 生成器 bug fix

### DIFF
--- a/packages/core/src/service/generator.ts
+++ b/packages/core/src/service/generator.ts
@@ -8,8 +8,8 @@ export enum GeneratorType {
 
 export interface IGeneratorOpts {
   key: string;
-  name?: string;
-  description?: string;
+  name: string;
+  description: string;
   type?: GeneratorType;
   checkEnable?: {
     (opts: { args: any }): boolean;
@@ -37,8 +37,8 @@ export interface IGeneratorOpts {
 
 export class Generator {
   key: IGeneratorOpts['key'];
-  name?: IGeneratorOpts['name'];
-  description?: IGeneratorOpts['description'];
+  name: IGeneratorOpts['name'];
+  description: IGeneratorOpts['description'];
   type?: IGeneratorOpts['type'];
   checkEnable?: IGeneratorOpts['checkEnable'];
   fn: IGeneratorOpts['fn'];

--- a/packages/create-umi/src/index.ts
+++ b/packages/create-umi/src/index.ts
@@ -24,7 +24,7 @@ export default async ({
   cwd: string;
   args: yParser.Arguments;
 }) => {
-  const [_, name] = args._;
+  const [name] = args._;
   let npmClient = 'pnpm' as any;
   let registry = 'https://registry.npmjs.org/';
   // test ignore prompts
@@ -90,9 +90,10 @@ export default async ({
     },
   ] as prompts.PromptObject[];
 
+  const target = name ? join(cwd, name) : cwd;
   const generator = new BaseGenerator({
     path: join(__dirname, '..', 'templates', args.plugin ? 'plugin' : 'app'),
-    target: name ? join(cwd, name) : cwd,
+    target,
     data: args.default
       ? testData
       : {
@@ -106,6 +107,6 @@ export default async ({
 
   if (!args.default) {
     // install
-    installWithNpmClient({ npmClient });
+    installWithNpmClient({ npmClient, cwd: target });
   }
 };

--- a/packages/preset-umi/src/commands/generators/api.ts
+++ b/packages/preset-umi/src/commands/generators/api.ts
@@ -12,6 +12,7 @@ export default (api: IApi) => {
   api.registerGenerator({
     key: 'api',
     name: 'Generator api',
+    description: 'Generate api route boilerplate code',
     async fn(opts) {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/component.ts
+++ b/packages/preset-umi/src/commands/generators/component.ts
@@ -13,6 +13,7 @@ export default (api: IApi) => {
   api.registerGenerator({
     key: 'component',
     name: 'Generate Component',
+    description: 'Generate component boilerplate code',
     type: GeneratorType.generate,
 
     fn: async (options) => {

--- a/packages/preset-umi/src/commands/generators/mock.ts
+++ b/packages/preset-umi/src/commands/generators/mock.ts
@@ -12,7 +12,8 @@ export default (api: IApi) => {
   api.registerGenerator({
     key: 'mock',
     type: GeneratorType.generate,
-    name: 'Generate mock code snippet',
+    name: 'Generate mock',
+    description: 'Generate mock boilerplate code',
 
     fn: async (opts) => {
       let [_, mockName] = opts.args._;

--- a/packages/preset-umi/src/commands/generators/tailwindcss.ts
+++ b/packages/preset-umi/src/commands/generators/tailwindcss.ts
@@ -35,7 +35,9 @@ export default (api: IApi) => {
         `
 module.exports = {
   content: [
-    './pages/**/*.tsx',
+    './src/pages/**/*.tsx',
+    './src/components/**.tsx',
+    './src/layouts/**.tsx',
   ],
 }
 `.trimLeft(),


### PR DESCRIPTION
#### create-umi 

cli args 参数以及去掉了node和 bin 信息（ https://github.com/umijs/umi-next/blob/1ee72d41008d425d6d2001d439d8fbac576cebe9/packages/create-umi/src/cli.ts#L5 ），最后取值的时候就直接使用第一个参数即可

#### tailwindcss generator 的配置文件更新
配合 src 目录 和 新增 layouts  和 components 

#### generator 描述文案缺失 
对应 ts定义 去掉 optional 
