### PR TITLE
fix: generate overwrite

### DIFF
--- a/packages/preset-umi/src/commands/generators/utils.ts
+++ b/packages/preset-umi/src/commands/generators/utils.ts
@@ -73,20 +73,31 @@ export class GeneratorHelper {
 
     const externalDeps = lodash.omit(deps, ['@umijs/plugins']);
 
+    // 已存在给出覆盖提示
+    Object.keys(externalDeps).forEach((key: string) => {
+      if (hasDeps({ name: key, pkg: api.pkg })) {
+        logger.info(
+          `${key} Version: ${api.pkg.devDependencies![key]} is replaced by ${
+            externalDeps[key]
+          }`,
+        );
+      }
+    });
+
     if (this.needInstallUmiPlugin) {
       api.pkg.devDependencies = {
         ...api.pkg.devDependencies,
         ...deps,
       };
       writeFileSync(api.pkgPath, JSON.stringify(api.pkg, null, 2));
-      logger.info('Write package.json');
+      logger.info(`addDevDeps: ${Object.keys(deps).join(',')}`);
     } else if (!lodash.isEmpty(externalDeps)) {
       api.pkg.devDependencies = {
         ...api.pkg.devDependencies,
         ...externalDeps,
       };
       writeFileSync(api.pkgPath, JSON.stringify(api.pkg, null, 2));
-      logger.info('Write package.json');
+      logger.info(`addDevDeps: ${Object.keys(deps).join(',')}`);
     }
   }
 


### PR DESCRIPTION
1、判断微生成器的生成路径如果已经存在，则不执行重写覆盖
![image](https://user-images.githubusercontent.com/11746742/163091995-aacb8d7b-2972-424b-ac4d-9d8d6da59d6f.png)
![image](https://user-images.githubusercontent.com/11746742/163092126-0e3aaacb-c788-4712-a651-47c7fae377f8.png)
2、修改 addDevDeps 的提示，打印日志是“增加了什么内容”。并且如果已经存在了，会提示版本号被覆盖。
![image](https://user-images.githubusercontent.com/11746742/163091709-2e73447a-ac9b-4e80-8081-dac3f3f43a27.png)
