### PR TITLE
feat(lint): use forked eslint-patch

### DIFF
--- a/packages/lint/compiled/@rushstack/eslint-patch/LICENSE
+++ b/packages/lint/compiled/@rushstack/eslint-patch/LICENSE
@@ -1,0 +1,24 @@
+@rushstack/eslint-patch
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/lint/compiled/@rushstack/eslint-patch/lib/modern-module-resolution.js
+++ b/packages/lint/compiled/@rushstack/eslint-patch/lib/modern-module-resolution.js
@@ -10,6 +10,12 @@
 const path = require('path');
 const fs = require('fs');
 const isModuleResolutionError = (ex) => typeof ex === 'object' && !!ex && 'code' in ex && ex.code === 'MODULE_NOT_FOUND';
+// ==== @umijs/lint fork start ====
+const getBuiltinPluginResolvePath = (pkg) => (
+  require('@umijs/lint/package.json').dependencies[pkg] &&
+  require.resolve('@umijs/lint/package.json')
+);
+// ==== @umijs/lint fork end ====
 // Module path for eslintrc.cjs
 // Example: ".../@eslint/eslintrc/dist/eslintrc.cjs"
 let eslintrcBundlePath = undefined;
@@ -182,7 +188,7 @@ if (!ConfigArrayFactory.__patched) {
             try {
                 ModuleResolver.resolve = function (moduleName, relativeToPath) {
                     // resolve using importerPath instead of relativeToPath
-                    return originalResolve.call(this, moduleName, importerPath);
+                    return originalResolve.call(this, moduleName, getBuiltinPluginResolvePath(moduleName) || importerPath);
                 };
                 return originalLoadPlugin.apply(this, arguments);
             }
@@ -198,7 +204,7 @@ if (!ConfigArrayFactory.__patched) {
             try {
                 ModuleResolver.resolve = function (moduleName, relativeToPath) {
                     // resolve using ctx.filePath instead of relativeToPath
-                    return originalResolve.call(this, moduleName, ctx.filePath);
+                    return originalResolve.call(this, moduleName, getBuiltinPluginResolvePath(moduleName) || ctx.filePath);
                 };
                 return originalLoadPlugin.apply(this, arguments);
             }

--- a/packages/lint/compiled/@rushstack/eslint-patch/lib/modern-module-resolution.js
+++ b/packages/lint/compiled/@rushstack/eslint-patch/lib/modern-module-resolution.js
@@ -1,0 +1,210 @@
+"use strict";
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+//
+// To correct how ESLint searches for plugin packages, add this line to the top of your project's .eslintrc.js file:
+//
+//    require("@rushstack/eslint-patch/modern-module-resolution");
+//
+const path = require('path');
+const fs = require('fs');
+const isModuleResolutionError = (ex) => typeof ex === 'object' && !!ex && 'code' in ex && ex.code === 'MODULE_NOT_FOUND';
+// Module path for eslintrc.cjs
+// Example: ".../@eslint/eslintrc/dist/eslintrc.cjs"
+let eslintrcBundlePath = undefined;
+// Module path for config-array-factory.js
+// Example: ".../@eslint/eslintrc/lib/config-array-factory"
+let configArrayFactoryPath = undefined;
+// Module path for relative-module-resolver.js
+// Example: ".../@eslint/eslintrc/lib/shared/relative-module-resolver"
+let moduleResolverPath = undefined;
+// Folder path where ESLint's package.json can be found
+// Example: ".../node_modules/eslint"
+let eslintFolder = undefined;
+// Probe for the ESLint >=8.0.0 layout:
+for (let currentModule = module;;) {
+    if (!eslintrcBundlePath) {
+        // For ESLint >=8.0.0, all @eslint/eslintrc code is bundled at this path:
+        //   .../@eslint/eslintrc/dist/eslintrc.cjs
+        try {
+            const eslintrcFolder = path.dirname(require.resolve('@eslint/eslintrc/package.json', { paths: [currentModule.path] }));
+            // Make sure we actually resolved the module in our call path
+            // and not some other spurious dependency.
+            if (path.join(eslintrcFolder, 'dist/eslintrc.cjs') === currentModule.filename) {
+                eslintrcBundlePath = path.join(eslintrcFolder, 'dist/eslintrc.cjs');
+            }
+        }
+        catch (ex) {
+            // Module resolution failures are expected, as we're walking
+            // up our require stack to look for eslint. All other errors
+            // are rethrown.
+            if (!isModuleResolutionError(ex)) {
+                throw ex;
+            }
+        }
+    }
+    else {
+        // Next look for a file in ESLint's folder
+        //   .../eslint/lib/cli-engine/cli-engine.js
+        try {
+            const eslintCandidateFolder = path.dirname(require.resolve('eslint/package.json', {
+                paths: [currentModule.path]
+            }));
+            // Make sure we actually resolved the module in our call path
+            // and not some other spurious dependency.
+            if (path.join(eslintCandidateFolder, 'lib/cli-engine/cli-engine.js') === currentModule.filename) {
+                eslintFolder = eslintCandidateFolder;
+                break;
+            }
+        }
+        catch (ex) {
+            // Module resolution failures are expected, as we're walking
+            // up our require stack to look for eslint. All other errors
+            // are rethrown.
+            if (!isModuleResolutionError(ex)) {
+                throw ex;
+            }
+        }
+    }
+    if (!currentModule.parent) {
+        break;
+    }
+    currentModule = currentModule.parent;
+}
+if (!eslintFolder) {
+    // Probe for the ESLint >=7.8.0 layout:
+    for (let currentModule = module;;) {
+        if (!configArrayFactoryPath) {
+            // For ESLint >=7.8.0, config-array-factory.js is at this path:
+            //   .../@eslint/eslintrc/lib/config-array-factory.js
+            try {
+                const eslintrcFolder = path.dirname(require.resolve('@eslint/eslintrc/package.json', {
+                    paths: [currentModule.path]
+                }));
+                if (path.join(eslintrcFolder, '/lib/config-array-factory.js') == currentModule.filename) {
+                    configArrayFactoryPath = path.join(eslintrcFolder, 'lib/config-array-factory.js');
+                    moduleResolverPath = path.join(eslintrcFolder, 'lib/shared/relative-module-resolver');
+                }
+            }
+            catch (ex) {
+                // Module resolution failures are expected, as we're walking
+                // up our require stack to look for eslint. All other errors
+                // are rethrown.
+                if (!isModuleResolutionError(ex)) {
+                    throw ex;
+                }
+            }
+        }
+        else {
+            // Next look for a file in ESLint's folder
+            //   .../eslint/lib/cli-engine/cli-engine.js
+            try {
+                const eslintCandidateFolder = path.dirname(require.resolve('eslint/package.json', {
+                    paths: [currentModule.path]
+                }));
+                if (path.join(eslintCandidateFolder, 'lib/cli-engine/cli-engine.js') == currentModule.filename) {
+                    eslintFolder = eslintCandidateFolder;
+                    break;
+                }
+            }
+            catch (ex) {
+                // Module resolution failures are expected, as we're walking
+                // up our require stack to look for eslint. All other errors
+                // are rethrown.
+                if (!isModuleResolutionError(ex)) {
+                    throw ex;
+                }
+            }
+        }
+        if (!currentModule.parent) {
+            break;
+        }
+        currentModule = currentModule.parent;
+    }
+}
+if (!eslintFolder) {
+    // Probe for the <7.8.0 layout:
+    for (let currentModule = module;;) {
+        // For ESLint <7.8.0, config-array-factory.js was at this path:
+        //   .../eslint/lib/cli-engine/config-array-factory.js
+        if (/[\\/]eslint[\\/]lib[\\/]cli-engine[\\/]config-array-factory\.js$/i.test(currentModule.filename)) {
+            eslintFolder = path.join(path.dirname(currentModule.filename), '../..');
+            configArrayFactoryPath = path.join(eslintFolder, 'lib/cli-engine/config-array-factory');
+            moduleResolverPath = path.join(eslintFolder, 'lib/shared/relative-module-resolver');
+            break;
+        }
+        if (!currentModule.parent) {
+            // This was tested with ESLint 6.1.0 .. 7.12.1.
+            throw new Error('Failed to patch ESLint because the calling module was not recognized.\n' +
+                'If you are using a newer ESLint version that may be unsupported, please create a GitHub issue:\n' +
+                'https://github.com/microsoft/rushstack/issues');
+        }
+        currentModule = currentModule.parent;
+    }
+}
+// Detect the ESLint package version
+const eslintPackageJson = fs.readFileSync(path.join(eslintFolder, 'package.json')).toString();
+const eslintPackageObject = JSON.parse(eslintPackageJson);
+const eslintPackageVersion = eslintPackageObject.version;
+const versionMatch = /^([0-9]+)\./.exec(eslintPackageVersion); // parse the SemVer MAJOR part
+if (!versionMatch) {
+    throw new Error('Unable to parse ESLint version: ' + eslintPackageVersion);
+}
+const eslintMajorVersion = Number(versionMatch[1]);
+if (!(eslintMajorVersion >= 6 && eslintMajorVersion <= 8)) {
+    throw new Error('The patch-eslint.js script has only been tested with ESLint version 6.x, 7.x, and 8.x.' +
+        ` (Your version: ${eslintPackageVersion})\n` +
+        'Consider reporting a GitHub issue:\n' +
+        'https://github.com/microsoft/rushstack/issues');
+}
+let ConfigArrayFactory;
+if (eslintMajorVersion === 8) {
+    ConfigArrayFactory = require(eslintrcBundlePath).Legacy.ConfigArrayFactory;
+}
+else {
+    ConfigArrayFactory = require(configArrayFactoryPath).ConfigArrayFactory;
+}
+if (!ConfigArrayFactory.__patched) {
+    ConfigArrayFactory.__patched = true;
+    let ModuleResolver;
+    if (eslintMajorVersion === 8) {
+        ModuleResolver = require(eslintrcBundlePath).Legacy.ModuleResolver;
+    }
+    else {
+        ModuleResolver = require(moduleResolverPath);
+    }
+    const originalLoadPlugin = ConfigArrayFactory.prototype._loadPlugin;
+    if (eslintMajorVersion === 6) {
+        // ESLint 6.x
+        ConfigArrayFactory.prototype._loadPlugin = function (name, importerPath, importerName) {
+            const originalResolve = ModuleResolver.resolve;
+            try {
+                ModuleResolver.resolve = function (moduleName, relativeToPath) {
+                    // resolve using importerPath instead of relativeToPath
+                    return originalResolve.call(this, moduleName, importerPath);
+                };
+                return originalLoadPlugin.apply(this, arguments);
+            }
+            finally {
+                ModuleResolver.resolve = originalResolve;
+            }
+        };
+    }
+    else {
+        // ESLint 7.x || 8.x
+        ConfigArrayFactory.prototype._loadPlugin = function (name, ctx) {
+            const originalResolve = ModuleResolver.resolve;
+            try {
+                ModuleResolver.resolve = function (moduleName, relativeToPath) {
+                    // resolve using ctx.filePath instead of relativeToPath
+                    return originalResolve.call(this, moduleName, ctx.filePath);
+                };
+                return originalLoadPlugin.apply(this, arguments);
+            }
+            finally {
+                ModuleResolver.resolve = originalResolve;
+            }
+        };
+    }
+}

--- a/packages/lint/compiled/@rushstack/eslint-patch/package.json
+++ b/packages/lint/compiled/@rushstack/eslint-patch/package.json
@@ -1,0 +1,1 @@
+{"name":"@rushstack/eslint-patch","license":"MIT"}

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@babel/core": "7.17.9",
     "@babel/eslint-parser": "7.17.0",
-    "@rushstack/eslint-patch": "1.1.2",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
@@ -36,6 +35,7 @@
     "stylelint-config-standard": "25.0.0"
   },
   "devDependencies": {
+    "@rushstack/eslint-patch": "1.1.2",
     "postcss-less": "6.0.0",
     "stylelint-config-css-modules": "4.1.0",
     "stylelint-config-prettier": "9.0.3",

--- a/packages/lint/src/config/eslint/setup.ts
+++ b/packages/lint/src/config/eslint/setup.ts
@@ -1,2 +1,2 @@
 // patch eslint plugin resolve logic
-require('@rushstack/eslint-patch/modern-module-resolution');
+require('../../../compiled/@rushstack/eslint-patch/lib/modern-module-resolution.js');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,7 +796,6 @@ importers:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/eslint-parser': 7.17.0_@babel+core@7.17.9
-      '@rushstack/eslint-patch': 1.1.2
       '@stylelint/postcss-css-in-js': 0.37.2_3c2bfa735c5d8a8695ad877879a67022
       '@typescript-eslint/eslint-plugin': 5.19.0_50220b0dbff47a6ddc17f4766348ae8f
       '@typescript-eslint/parser': 5.19.0_typescript@4.6.3
@@ -808,6 +807,7 @@ importers:
       postcss-syntax: 0.36.2_postcss@8.4.12
       stylelint-config-standard: 25.0.0
     devDependencies:
+      '@rushstack/eslint-patch': 1.1.2
       postcss-less: 6.0.0_postcss@8.4.12
       stylelint-config-css-modules: 4.1.0
       stylelint-config-prettier: 9.0.3
@@ -6585,7 +6585,7 @@ packages:
 
   /@rushstack/eslint-patch/1.1.2:
     resolution: {integrity: sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA==}
-    dev: false
+    dev: true
 
   /@sideway/address/4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}


### PR DESCRIPTION
## Description

解决 `umi`、`@umijs/max`、`bigfish` 包裹导出 `@umijs/lint` 配置时，无法从 `@umijs/lint` 寻找插件依赖的问题，解法：
1. 预打包 `@rushstack/eslint-patch`，包比较特殊无法走脚本，目前是手动复制的
2. 修改 `@rushstack/eslint-patch` 的产物中的解析逻辑，部分插件从 `@umijs/lint` 开始 resolve，diff：https://github.com/umijs/umi-next/commit/7280a75bfbacc044fd7172fab57ed9297dd78a19