### PR TITLE
feat(preset-umi): handle ts prompt problems caused by @fs

### DIFF
--- a/examples/bigfish/.umirc.ts
+++ b/examples/bigfish/.umirc.ts
@@ -70,6 +70,7 @@ export default defineConfig({
       ],
     },
   },
+  // vite: {}
   // esmi: { cdnOrigin: 'https://npmcore-pre.alipay.com' },
   // lowImport: {},
 });

--- a/examples/bigfish/tsconfig.json
+++ b/examples/bigfish/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": true,
     "paths": {
       "@/*": ["*"],
-      "@@/*": ["./.umi/*"]
+      "@@/*": ["./.umi/*"],
+      "@fs/*": ["*"]
     },
     "allowSyntheticDefaultImports": true
   },

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -79,8 +79,6 @@ export default (api: IApi) => {
       ...memo.alias,
       '@': args.paths.absSrcPath,
       '@@': args.paths.absTmpPath,
-      // like vite, use to pre-bundling dependencies in vite mode
-      '@fs': '/',
     };
     return memo;
   });

--- a/packages/preset-umi/src/features/vite/vite.ts
+++ b/packages/preset-umi/src/features/vite/vite.ts
@@ -11,6 +11,15 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
+  api.modifyConfig((memo) => {
+    memo.alias = {
+      ...memo.alias,
+      // like vite, use to pre-bundling dependencies in vite mode
+      '@fs': '/',
+    };
+    return memo;
+  });
+
   // scan deps into api.appData by default for vite mode
   api.register({
     key: 'onBeforeCompiler',

--- a/packages/preset-umi/src/features/vite/vite.ts
+++ b/packages/preset-umi/src/features/vite/vite.ts
@@ -12,11 +12,8 @@ export default (api: IApi) => {
   });
 
   api.modifyConfig((memo) => {
-    memo.alias = {
-      ...memo.alias,
-      // like vite, use to pre-bundling dependencies in vite mode
-      '@fs': '/',
-    };
+    // like vite, use to pre-bundling dependencies in vite mode
+    memo.alias['@fs'] = '/';
     return memo;
   });
 

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -109,8 +109,9 @@ export default (api: IApi) => {
         .filter((text) => text !== false)
         .join('\n');
 
-      // transform imports for all javascript-like files
-      if (/\.(t|j)sx?$/.test(absPath)) {
+      const enableVite = !!api.config.vite;
+      // transform imports for all javascript-like files only vite mode enable
+      if (/\.(t|j)sx?$/.test(absPath) && enableVite) {
         content = transformIEAR({ content, path: absPath }, api);
       }
 

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -110,7 +110,7 @@ export default (api: IApi) => {
         .join('\n');
 
       // transform imports for all javascript-like files only vite mode enable
-      if (/\.(t|j)sx?$/.test(absPath) && api.appData.vite) {
+      if (api.appData.vite && /\.(t|j)sx?$/.test(absPath)) {
         content = transformIEAR({ content, path: absPath }, api);
       }
 

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -109,9 +109,8 @@ export default (api: IApi) => {
         .filter((text) => text !== false)
         .join('\n');
 
-      const enableVite = !!api.config.vite;
       // transform imports for all javascript-like files only vite mode enable
-      if (/\.(t|j)sx?$/.test(absPath) && enableVite) {
+      if (/\.(t|j)sx?$/.test(absPath) && api.appData.vite) {
         content = transformIEAR({ content, path: absPath }, api);
       }
 

--- a/packages/preset-umi/src/utils/transformIEAR.test.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.test.ts
@@ -75,14 +75,14 @@ describe('transform path for import/export/await-import/require', () => {
           content: cases.join('\n'),
           path: '/path/to/.umi/plugin-self/index.ts',
         },
-        { paths: { absTmpPath: '/path/to/.umi' } } as any,
+        { paths: { absTmpPath: '/path/to/.umi' }, cwd: '/path/to' } as any,
       ),
     ).toEqual(
       cases
         .join('\n')
         .replace('/path/to/.umi', '..')
         .replace('/path/to/.umi/plugin-self', '.')
-        .replace('/path/to/node_modules', '@fs/path/to/node_modules'),
+        .replace('/path/to/node_modules', '@fs./node_modules'),
     );
   });
 });

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -100,7 +100,7 @@ export default function transformIEAR(
       // why @fs
       // 由于我们临时文件下大量绝对路径的引用，而绝对路径的引用不会被 Vite 预编译
       // 增加@fs后绝对路径会导致ts 提示失效, 这里转为相对路径解决
-      absPath = `@fs./${relative(api.cwd, absPath)}`;
+      absPath = `@fs./${winPath(relative(api.cwd, absPath))}`;
     }
 
     return `${prefix}${quote}${absPath}${quote}`;

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -99,7 +99,8 @@ export default function transformIEAR(
       // transform node_modules absolute imports
       // why @fs
       // 由于我们临时文件下大量绝对路径的引用，而绝对路径的引用不会被 Vite 预编译
-      absPath = `@fs${absPath}`;
+      // 增加@fs后绝对路径会导致ts 提示失效, 这里转为相对路径解决
+      absPath = `@fs./${relative(api.cwd, absPath)}`;
     }
 
     return `${prefix}${quote}${absPath}${quote}`;


### PR DESCRIPTION
处理因为 @fs 导致的 ts 声明失效问题

## 改动点

- @fs 仅针对 vite 模式开启
- @fs 依赖的三方路径绝对路径会转为相对路径
- @fs 的alias 移动到 feature/vite.ts 中