### PR TITLE
feat(plugin-docs): Add theme config for hide the theme switch

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import React from 'react';
+import { useThemeContext } from './context';
 import Github from './Github';
 import LangSwitch from './LangSwitch';
 import Logo from './Logo';
@@ -13,6 +14,7 @@ interface HeadProps {
 }
 
 export default (props: HeadProps) => {
+  const { themeConfig } = useThemeContext()!;
   return (
     <div
       className="w-full flex flex-row items-center justify-between
@@ -35,9 +37,11 @@ export default (props: HeadProps) => {
         <div className="ml-4 hidden lg:block">
           <LangSwitch />
         </div>
-        <div className="ml-4 hidden lg:block">
-          <ThemeSwitch />
-        </div>
+        {themeConfig.themeSwitch !== false && (
+          <div className="ml-4 hidden lg:block">
+            <ThemeSwitch />
+          </div>
+        )}
         <div className="ml-4 hidden lg:block">
           <Github />
         </div>

--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -37,7 +37,7 @@ export default (props: HeadProps) => {
         <div className="ml-4 hidden lg:block">
           <LangSwitch />
         </div>
-        {themeConfig.themeSwitch !== false && (
+        {themeConfig.themeSwitch && (
           <div className="ml-4 hidden lg:block">
             <ThemeSwitch />
           </div>

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -1,12 +1,20 @@
 import cx from 'classnames';
 import React, { useEffect, useState } from 'react';
+import { useThemeContext } from './context';
 import MoonIcon from './icons/moon.png';
 import SunIcon from './icons/sun.png';
 
 export default () => {
   const [toggle, setToggle] = useState<Boolean>();
+  const { themeConfig } = useThemeContext()!;
 
   useEffect(() => {
+    // If themeConfig disabled the themeSwitch, just set to light theme
+    if (themeConfig.themeSwitch === false) {
+      document.body.classList.remove('dark');
+      return;
+    }
+
     // 初始化，获取过去曾经设定过的主题，或是系统当前的主题
     if (toggle === undefined) {
       if (localStorage.getItem('theme') === 'dark') {

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -10,7 +10,7 @@ export default () => {
 
   useEffect(() => {
     // If themeConfig disabled the themeSwitch, just set to light theme
-    if (themeConfig.themeSwitch === false) {
+    if (!themeConfig.themeSwitch) {
       document.body.classList.remove('dark');
       return;
     }

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -24,6 +24,7 @@ interface IContext {
       title: string;
       link?: string;
     };
+    themeSwitch?: boolean;
   };
   location: {
     pathname: string;

--- a/theme.config.ts
+++ b/theme.config.ts
@@ -104,6 +104,7 @@ export default {
       ],
     },
   ],
+  themeSwitch: true,
   announcement: {
     title: 'Umi4 即将推出!!!',
     link: 'https://github.com/umijs/umi-next',


### PR DESCRIPTION
在 `plugin-docs` 的 `themeConfig` 增加了 `themeSwitch` 配置项，当 `themeSwitch` 为 `false` 时，顶部导航栏右边就不会显示主题切换开关。

<img width="622" alt="Screen Shot 2022-04-20 at 4 44 21 PM" src="https://user-images.githubusercontent.com/21105863/164188614-651ebf9e-5bfe-4dd0-9228-5f8586191eee.png">

<img width="622" alt="Screen Shot 2022-04-20 at 4 44 34 PM" src="https://user-images.githubusercontent.com/21105863/164188667-a8e86848-0768-420f-b4ab-37e3d4045301.png">

