### PR TITLE
feat(preset-umi): better onCheckCode

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -1,4 +1,4 @@
-import { AsyncSeriesWaterfallHook } from '@umijs/bundler-utils/compiled/tapable';
+import { AsyncSeriesWaterfallHook, SyncWaterfallHook } from '@umijs/bundler-utils/compiled/tapable';
 import { chalk, lodash, yParser } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync } from 'fs';
@@ -90,12 +90,27 @@ export class Service {
     assert(existsSync(this.cwd), `Invalid cwd ${this.cwd}, it's not found.`);
   }
 
-  async applyPlugins<T>(opts: {
+  // overload, for apply event synchronously
+  applyPlugins<T>(opts: {
+    key: string;
+    type?: ApplyPluginsType.event;
+    initialValue?: any;
+    args?: any;
+    sync: true;
+  }): typeof opts.initialValue | T;
+  applyPlugins<T>(opts: {
     key: string;
     type?: ApplyPluginsType;
     initialValue?: any;
     args?: any;
-  }): Promise<typeof opts.initialValue | T> {
+  }): Promise<typeof opts.initialValue | T>;
+  applyPlugins<T>(opts: {
+    key: string;
+    type?: ApplyPluginsType;
+    initialValue?: any;
+    args?: any;
+    sync?: boolean;
+  }): Promise<typeof opts.initialValue | T> | (typeof opts.initialValue | T) {
     const hooks = this.hooks[opts.key] || [];
     let type = opts.type;
     // guess type from key
@@ -138,7 +153,7 @@ export class Service {
             },
           );
         }
-        return (await tAdd.promise(opts.initialValue || [])) as T;
+        return tAdd.promise(opts.initialValue || []) as Promise<T>;
       case ApplyPluginsType.modify:
         const tModify = new AsyncSeriesWaterfallHook(['memo']);
         for (const hook of hooks) {
@@ -160,8 +175,33 @@ export class Service {
             },
           );
         }
-        return (await tModify.promise(opts.initialValue)) as T;
+        return tModify.promise(opts.initialValue) as Promise<T>;
       case ApplyPluginsType.event:
+        if (opts.sync) {
+          const tEvent = new SyncWaterfallHook(['_']);
+          hooks.forEach((hook) => {
+            if (this.isPluginEnable(hook)) {
+              tEvent.tap(
+                {
+                  name: hook.plugin.key,
+                  stage: hook.stage || 0,
+                  before: hook.before,
+                },
+                () => {
+                  const dateStart = new Date();
+                  hook.fn(opts.args);
+                  hook.plugin.time.hooks[opts.key] ||= [];
+                  hook.plugin.time.hooks[opts.key].push(
+                    new Date().getTime() - dateStart.getTime(),
+                  );
+                },
+              );
+            }
+          });
+
+          return tEvent.call(1) as T;
+        }
+
         const tEvent = new AsyncSeriesWaterfallHook(['_']);
         for (const hook of hooks) {
           if (!this.isPluginEnable(hook)) continue;
@@ -181,7 +221,7 @@ export class Service {
             },
           );
         }
-        return (await tEvent.promise(1)) as T;
+        return tEvent.promise(1) as Promise<T>;
       default:
         throw new Error(
           `applyPlugins failed, type is not defined or is not matched, got ${opts.type}.`,

--- a/packages/preset-umi/src/features/check/check.ts
+++ b/packages/preset-umi/src/features/check/check.ts
@@ -24,13 +24,13 @@ export default (api: IApi) => {
     });
   });
 
-  api.onCheckCode((args) => {
+  api.onCheckCode(({ CodeFrameError, ...args }) => {
     // Fixed version import is not allowed
     // e.g. import { X } from '_@ant-design_icons@4.7.0@ant-design/icons'
     if (['cnpm', 'tnpm'].includes(api.appData.npmClient)) {
-      args.imports.forEach(({ source }) => {
+      args.imports.forEach(({ source, loc }) => {
         if (!isAbsolutePath(source) && /@\d/.test(source)) {
-          throw new Error(`${source} is not allowed to import.`);
+          throw new CodeFrameError(`${source} is not allowed to import.`, loc);
         }
       });
     }

--- a/packages/preset-umi/src/features/transform/CodeFrameError.ts
+++ b/packages/preset-umi/src/features/transform/CodeFrameError.ts
@@ -1,0 +1,10 @@
+import type { SourceLocation } from '@umijs/bundler-utils/compiled/babel/code-frame';
+
+export default class CodeFrameError extends Error {
+  location: SourceLocation;
+
+  constructor(msg: string, location: SourceLocation) {
+    super(msg);
+    this.location = location;
+  }
+}

--- a/packages/preset-umi/src/features/transform/transform.ts
+++ b/packages/preset-umi/src/features/transform/transform.ts
@@ -34,7 +34,7 @@ export default (api: IApi) => {
                       })}\n`,
                     );
                   } else if (err instanceof Error) {
-                    // throw normal error with red message
+                    // throw normal error with red text color
                     throw new Error(chalk.redBright(err.message));
                   } else {
                     // log error

--- a/packages/preset-umi/src/features/transform/transform.ts
+++ b/packages/preset-umi/src/features/transform/transform.ts
@@ -1,5 +1,6 @@
 import { IApi } from '../../types';
 import babelPlugin from './babelPlugin';
+import CodeFrameError from './CodeFrameError';
 
 export default (api: IApi) => {
   api.addBeforeBabelPresets(() => {
@@ -14,7 +15,11 @@ export default (api: IApi) => {
               onCheckCode({ args }: any) {
                 api.applyPlugins({
                   key: 'onCheckCode',
-                  args: args,
+                  args: {
+                    ...args,
+                    CodeFrameError,
+                  },
+                  sync: true,
                 });
               },
             },

--- a/packages/preset-umi/src/features/transform/transform.ts
+++ b/packages/preset-umi/src/features/transform/transform.ts
@@ -1,3 +1,5 @@
+import { codeFrameColumns } from '@umijs/bundler-utils/compiled/babel/code-frame';
+import { chalk } from '@umijs/utils';
 import { IApi } from '../../types';
 import babelPlugin from './babelPlugin';
 import CodeFrameError from './CodeFrameError';
@@ -13,14 +15,32 @@ export default (api: IApi) => {
               cwd: api.cwd,
               absTmpPath: api.paths.absTmpPath,
               onCheckCode({ args }: any) {
-                api.applyPlugins({
-                  key: 'onCheckCode',
-                  args: {
-                    ...args,
-                    CodeFrameError,
-                  },
-                  sync: true,
-                });
+                try {
+                  api.applyPlugins({
+                    key: 'onCheckCode',
+                    args: {
+                      ...args,
+                      CodeFrameError,
+                    },
+                    sync: true,
+                  });
+                } catch (err) {
+                  if (err instanceof CodeFrameError) {
+                    // throw with babel code frame error
+                    throw new Error(
+                      `\n${codeFrameColumns(args.code, err.location, {
+                        highlightCode: true,
+                        message: err.message,
+                      })}\n`,
+                    );
+                  } else if (err instanceof Error) {
+                    // throw normal error with red message
+                    throw new Error(chalk.redBright(err.message));
+                  } else {
+                    // log error
+                    api.logger.error(err);
+                  }
+                }
               },
             },
           ],

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -13,6 +13,7 @@ import type {
 import { Env } from '@umijs/core';
 import type { CheerioAPI } from '@umijs/utils/compiled/cheerio';
 import type { InlineConfig as ViteInlineConfig } from 'vite';
+import type CodeFrameError from './features/transform/CodeFrameError';
 
 export { UmiApiRequest, UmiApiResponse } from './features/apiRoute';
 export { webpack, IConfig };
@@ -127,6 +128,7 @@ export type IApi = PluginAPI &
     onCheckCode: IEvent<{
       cjsExports: string[];
       code: string;
+      CodeFrameError: typeof CodeFrameError;
       exports: any[];
       file: string;
       imports: {


### PR DESCRIPTION
## Description

改进 `onCheckCode` hook，便于开发者抛出精确到行列的错误信息给用户（如 Bigfish 强约束）：
1. `onCheckCode` hook 改为同步模式，使得检查中抛出的错误可以同时在 webpack 的 compiletime 和 runtime 展示，并且阻断编译
2. `onCheckCode` 参数增加 `CodeFrameError`，抛出该错误可以实现精确到行列的报错，对用户更友好，同时也兜底支持原生 `Error`

用法：
```ts
api.onCheckCode({ CodeFrameError, ...args }) {
  args.imports.forEach(({ source, loc }) => {
    if (source xxx) throw new CodeFrameError('balabala', loc);
  });
}
```

其他相关修改：
1. `event` 类型的插件 Hook 支持同步模式，`applyPlugins` 时传递 `sync: true` 即可切换并获得正确的类型
2. check.ts 中对类似 `_@ant-design_icons@4.7.0@ant-design/icons` 引入的检测改为 `CodeFrameError`

示例效果：
![error](https://user-images.githubusercontent.com/5035925/164276156-6f229aad-733d-4cf4-a425-6f81d87ee496.jpg)


