### PR TITLE
ci: improve test timeout in ci for windows platform

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -29,7 +29,7 @@ export function createConfig(opts?: {
       '^.+\\.(css|less|sass|scss|stylus)$':
         require.resolve('identity-obj-proxy'),
     },
-    testTimeout: 30000,
+    testTimeout: (process.env.CI ? 60 : 30) * 1e3,
     modulePathIgnorePatterns: [
       '<rootDir>/packages/.+/compiled',
       '<rootDir>/packages/.+/fixtures',


### PR DESCRIPTION
ci test 的 windows 机器性能太差，延长一下 timeout 时间