### PR TITLE
feat(plugin-docs): Add configs for customize head of plugin-docs

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -22,11 +22,7 @@ export default (props: HeadProps) => {
     >
       <div className="flex flex-row items-center">
         <Logo />
-        {themeConfig.leftNavComponents?.map((Comp, i) => (
-          <div className="ml-4 hidden lg:block" key={i}>
-            <Comp />
-          </div>
-        ))}
+        {themeConfig.extraNavLeft && <themeConfig.extraNavLeft />}
       </div>
       <div className="flex flex-row items-center">
         <Search />
@@ -50,11 +46,7 @@ export default (props: HeadProps) => {
         <div className="ml-4 hidden lg:block">
           <Github />
         </div>
-        {themeConfig.rightNavComponents?.map((Comp, i) => (
-          <div className="ml-4 hidden lg:block" key={i}>
-            <Comp />
-          </div>
-        ))}
+        {themeConfig.extraNavRight && <themeConfig.extraNavRight />}
       </div>
     </div>
   );

--- a/packages/plugin-docs/client/theme-doc/Head.tsx
+++ b/packages/plugin-docs/client/theme-doc/Head.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import React from 'react';
+import { useThemeContext } from './context';
 import Github from './Github';
 import LangSwitch from './LangSwitch';
 import Logo from './Logo';
@@ -13,12 +14,20 @@ interface HeadProps {
 }
 
 export default (props: HeadProps) => {
+  const { themeConfig } = useThemeContext()!;
   return (
     <div
       className="w-full flex flex-row items-center justify-between
       border-b-gray-100 border-b-2 pt-4 pb-4 px-4 lg:px-12 dark:border-b-gray-800"
     >
-      <Logo />
+      <div className="flex flex-row items-center">
+        <Logo />
+        {themeConfig.leftNavComponents?.map((Comp, i) => (
+          <div className="ml-4 hidden lg:block" key={i}>
+            <Comp />
+          </div>
+        ))}
+      </div>
       <div className="flex flex-row items-center">
         <Search />
         {/* 小屏幕显示打开菜单的按钮 */}
@@ -41,6 +50,11 @@ export default (props: HeadProps) => {
         <div className="ml-4 hidden lg:block">
           <Github />
         </div>
+        {themeConfig.rightNavComponents?.map((Comp, i) => (
+          <div className="ml-4 hidden lg:block" key={i}>
+            <Comp />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/packages/plugin-docs/client/theme-doc/Logo.tsx
+++ b/packages/plugin-docs/client/theme-doc/Logo.tsx
@@ -5,14 +5,15 @@ import useLanguage from './useLanguage';
 export default () => {
   const { themeConfig, components } = useThemeContext()!;
   const { isFromPath, currentLanguage } = useLanguage();
-
-  // @ts-ignore
-  const { logo } = themeConfig;
+  const Logo = themeConfig.logo;
 
   return (
     <components.Link to={isFromPath ? '/' + currentLanguage?.locale : '/'}>
       <div className="flex flex-row items-center">
-        <img src={logo} className="w-8 h-8" alt="logo" />
+        {typeof Logo === 'string' && (
+          <img src={Logo} className="w-8 h-8" alt="logo" />
+        )}
+        {typeof Logo === 'function' && <Logo />}
         <div className="text-xl font-extrabold ml-2 dark:text-white">
           {themeConfig.title}
         </div>

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -9,12 +9,16 @@ interface IContext {
     github: string;
     // 键盘搜索的快捷键，参考 https://github.com/madrobby/keymaster
     searchHotKey?: string | { macos: string; windows: string };
-    logo: string;
+    logo: string | React.FC;
     // 在设置文件中声明该项目的国际化功能支持的语言
     i18n?: { locale: string; text: string }[];
     // 插件会从 docs/locales 内将所有 json 文件注入到 themeConfig 中
     // 供 useLanguage 使用
     locales: { [locale: string]: { [key: string]: string } };
+    // 顶部导航栏右侧自定义组件
+    rightNavComponents: React.FC[];
+    // 底部导航栏左侧自定义组件
+    leftNavComponents: React.FC[];
     navs: {
       path: string;
       title: string;

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -16,9 +16,9 @@ interface IContext {
     // 供 useLanguage 使用
     locales: { [locale: string]: { [key: string]: string } };
     // 顶部导航栏右侧自定义组件
-    rightNavComponents: React.FC[];
+    extraNavRight?: React.FC;
     // 底部导航栏左侧自定义组件
-    leftNavComponents: React.FC[];
+    extraNavLeft?: React.FC;
     navs: {
       path: string;
       title: string;

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -9,16 +9,16 @@ interface IContext {
     github: string;
     // 键盘搜索的快捷键，参考 https://github.com/madrobby/keymaster
     searchHotKey?: string | { macos: string; windows: string };
-    logo: string | React.FC;
+    logo: string | React.ComponentType;
     // 在设置文件中声明该项目的国际化功能支持的语言
     i18n?: { locale: string; text: string }[];
     // 插件会从 docs/locales 内将所有 json 文件注入到 themeConfig 中
     // 供 useLanguage 使用
     locales: { [locale: string]: { [key: string]: string } };
     // 顶部导航栏右侧自定义组件
-    extraNavRight?: React.FC;
+    extraNavRight?: React.ComponentType;
     // 底部导航栏左侧自定义组件
-    extraNavLeft?: React.FC;
+    extraNavLeft?: React.ComponentType;
     navs: {
       path: string;
       title: string;


### PR DESCRIPTION
为 `plugin-docs` 增加了透过配置文件 `theme.config.ts` 对顶部导航栏进行自定义扩展的能力。

### 使用场景 1 - 自定义左上方 Logo

```ts
// theme.config.ts

import MyCustomLogo from '@components/MyCustomLogo';

export default {
  logo: MyCustomLogo
};
```

### 使用场景 2 - 自定义导航栏左方控件

```ts
// theme.config.ts

import VersionSwitch from '@components/VersionSwitch';

export default {
  leftNavComponents: [ VersionSwitch ]
};
```

### 使用场景 3 - 自定义导航栏右方控件

```ts
// theme.config.ts

import VersionSwitch from '@components/VersionSwitch';

export default {
  rightNavComponents: [ VersionSwitch ]
};
```