### PR TITLE
feat(preset-umi): add kind for onCheckCode import specifiers

### DIFF
--- a/docs/docs/api/plugin-api.md
+++ b/docs/docs/api/plugin-api.md
@@ -497,7 +497,7 @@ args: {
     loc: any;
     default: string;
     namespace: string;
-    specifiers: Record<string, string>;
+    specifiers: Record<string, { name: string; kind: babelImportKind }>;
   }[];
   exports: any[];
   cjsExports: string[]; 

--- a/packages/preset-umi/src/features/transform/babelPlugin.test.ts
+++ b/packages/preset-umi/src/features/transform/babelPlugin.test.ts
@@ -57,12 +57,12 @@ xtest('import namespace', () => {
 });
 
 xtest('import specifiers', () => {
-  const { imports } = doTransform({ code: `import { a, b } from 'a';` });
+  const { imports } = doTransform({ code: `import { a, type b } from 'a';` });
   expect(imports.map(formatImport)).toEqual([
     {
       specifiers: {
-        a: 'a',
-        b: 'b',
+        a: { name: 'a', kind: 'value' },
+        b: { name: 'b', kind: 'type' },
       },
       source: 'a',
     },

--- a/packages/preset-umi/src/features/transform/babelPlugin.ts
+++ b/packages/preset-umi/src/features/transform/babelPlugin.ts
@@ -78,7 +78,10 @@ export default function () {
                     t.isIdentifier(specifier.imported)
                       ? specifier.imported.name
                       : specifier.imported.value
-                  ] = specifier.local.name;
+                  ] = {
+                    name: specifier.local.name,
+                    kind: specifier.importKind,
+                  };
                 }
               });
               cache.get(file).imports.push(ret);

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -1,4 +1,5 @@
 // sort-object-keys
+import type { ImportDeclaration } from '@umijs/bundler-utils/compiled/@babel/types';
 import type { RequestHandler, webpack } from '@umijs/bundler-webpack';
 import type WebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import type { IConfig } from '@umijs/bundler-webpack/dist/types';
@@ -136,7 +137,7 @@ export type IApi = PluginAPI &
         loc: any;
         namespace: string;
         source: string;
-        specifiers: Record<string, string>;
+        specifiers: Record<string, { kind: ImportDeclaration; name: string }>;
       }[];
       isFromTmp: boolean;
     }>;


### PR DESCRIPTION
## Description

onCheckCode 的 specifiers 信息添加 babel 的 `importKind`，用于判读引入类型