### PR TITLE
fix(plugin-docs): Fix #644 TOC link makes page reload loop

### DIFF
--- a/packages/plugin-docs/src/compiler.ts
+++ b/packages/plugin-docs/src/compiler.ts
@@ -38,8 +38,7 @@ function MDXContent(props = {}) {
   useEffect(() => {
     if (window.location.hash.length !== 0) {
       const hash = window.location.hash;
-      window.location.hash = '';
-      window.location.hash = hash;
+      document.getElementById(hash.slice(1))?.scrollIntoView();
     }
   }, []);
 


### PR DESCRIPTION
修复了 #644 问题 - `plugin-docs` 点击 TOC 会导致页面陷入加载循环的问题。

问题原因是当前 `useLocation` 会依赖 `window.location` 对象，导致 `window.location.hash` 发生变化时，触发了页面组件的重新加载，而页面组件内有 `useEffect` 会重新设置 `window.location.hash` (为了让带着 hash 进入文档的用户可以定位到对应的位置），结果重新设置的结果导致了页面组件又重新加载了，陷入死循环。