### PR TITLE
fix(plugin-docs): Fix #645 mdx error if there is brackets in docs

### DIFF
--- a/docs/docs/api/runtime-config.md
+++ b/docs/docs/api/runtime-config.md
@@ -7,12 +7,12 @@
 
 ## 配置项
 
-### patchRoutes({ routes })
+### patchRoutes(\{ routes \})
 
 修改路由。
 
 ```ts
-export function patchRoutes({ routes }) {
+export function patchRoutes(\{ routes \}) {
   for (let key of routes){
     // do something
   }
@@ -43,7 +43,7 @@ export function render(oldRender){
 ```
 该例子的目的是在渲染之前做权限校验。
 
-### onRouteChange({ routes, clientRoutes, location, action })
+### onRouteChange(\{ routes, clientRoutes, location, action \})
 
 在初始加载和路由切换时做一些事情。
 

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -7,7 +7,7 @@ function getLinkFromTitle(title: string) {
   return title
     .toLowerCase()
     .replace(/\s/g, '-')
-    .replace(/[（）]/g, '');
+    .replace(/[（）()\\{},]/g, '');
 }
 
 export default () => {
@@ -53,7 +53,7 @@ export default () => {
                 className={item.level > 2 ? 'text-sm' : ''}
                 href={'#' + getLinkFromTitle(item.title)}
               >
-                {item.title}
+                {item.title.replace(/\\{/g, '{').replace(/\\}/g, '}')}
               </a>
             </li>
           );


### PR DESCRIPTION
修复了 #645 在 `plugin-docs` 文档中使用大括号 `{` `}` 会导致 mdx 误判导致编译报错的问题