### PR TITLE
feat(plugin-docs): Add dropdown for nav items

### DIFF
--- a/packages/plugin-docs/client/theme-doc/NavBar.tsx
+++ b/packages/plugin-docs/client/theme-doc/NavBar.tsx
@@ -1,27 +1,70 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
 
 export default () => {
-  const { components, themeConfig } = useThemeContext()!;
-  const lang = useLanguage();
+  const { themeConfig } = useThemeContext()!;
   return (
     <ul className="flex">
-      {themeConfig.navs.map((nav: any) => {
-        return (
-          <li key={nav.path} className="ml-4 dark:text-white">
-            <components.Link
-              to={
-                lang.isFromPath
-                  ? lang.currentLanguage?.locale + nav.path
-                  : nav.path
-              }
-            >
-              {lang.render(nav.title)}
-            </components.Link>
-          </li>
-        );
-      })}
+      {themeConfig.navs.map((nav: any) => (
+        <NavItem nav={nav} key={nav.path} />
+      ))}
     </ul>
   );
 };
+
+interface NavItemProps {
+  nav: {
+    path: string;
+    title: string;
+    dropdown?: {
+      title: string;
+      path: string;
+    }[];
+  };
+}
+
+function NavItem(props: NavItemProps) {
+  const { components } = useThemeContext()!;
+  const { nav } = props;
+  const lang = useLanguage();
+  const [isExpanded, setExpanded] = useState(false);
+  return (
+    <li
+      className="ml-8 dark:text-white relative"
+      onMouseEnter={() => nav.dropdown && setExpanded(true)}
+      onMouseLeave={() => nav.dropdown && setExpanded(false)}
+    >
+      <components.Link
+        to={
+          lang.isFromPath ? lang.currentLanguage?.locale + nav.path : nav.path
+        }
+      >
+        {lang.render(nav.title)}
+      </components.Link>
+      {nav.dropdown && (
+        <div
+          style={{ maxHeight: isExpanded ? nav.dropdown.length * 48 : 0 }}
+          className="absolute transition-all duration-300 w-32 rounded-lg
+       cursor-pointer shadow overflow-hidden top-8"
+        >
+          {nav.dropdown.map((n) => (
+            <components.Link
+              key={n.path}
+              to={
+                lang.isFromPath ? lang.currentLanguage?.locale + n.path : n.path
+              }
+            >
+              <p
+                className="p-2 bg-white dark:bg-gray-700 dark:text-white
+            hover:bg-gray-50 transition duration-300"
+              >
+                {n.title}
+              </p>
+            </components.Link>
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/packages/plugin-docs/client/theme-doc/context.ts
+++ b/packages/plugin-docs/client/theme-doc/context.ts
@@ -22,6 +22,7 @@ interface IContext {
     navs: {
       path: string;
       title: string;
+      dropdown?: { title: string; path: string }[];
       children: any[];
     }[];
     announcement?: {


### PR DESCRIPTION
帮 `plugin-docs` 新增了从 `theme.config.ts` 配置文件为顶部导航栏增加下拉选单（二级导航）的能力。

### 配置方式

```ts
// theme.config.ts

export default {

  // ...

  navs: [
    {
      path: '/docs',
      title: 'Docs',
      type: 'nav',
      dropdown: [
        { title: 'Tutorials', path: '/docs/tutorials/getting-started' }
      ],
      children: [ /* ... */ ]
    }],

  // ...
};
```

<img width="726" alt="Screen Shot 2022-04-22 at 3 03 23 PM" src="https://user-images.githubusercontent.com/21105863/164622710-cde4b91e-1fb7-4c8d-bbab-f67b120a3034.png">
