### PR TITLE
fix(umi): correct export for http-proxy-middleware

### DIFF
--- a/packages/umi/src/pluginUtils.ts
+++ b/packages/umi/src/pluginUtils.ts
@@ -1,4 +1,4 @@
 import express from '@umijs/bundler-utils/compiled/express';
-import httpProxyMiddleware from '@umijs/bundler-webpack/compiled/http-proxy-middleware';
+import * as httpProxyMiddleware from '@umijs/bundler-webpack/compiled/http-proxy-middleware';
 export * from '@umijs/utils';
 export { httpProxyMiddleware, express };


### PR DESCRIPTION
## Description

修复 `htttp-proxy-middleware` 的导出，该包没有 default 导出，之前的方式会 undefined