### PR TITLE
wip: Fix/msfu, webpack cache race

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -199,6 +199,10 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
       buildDependencies: {
         config: opts.cache.buildDependencies || [],
       },
+      name: 'umi',
+      idleTimeout: 0,
+      idleTimeoutAfterLargeChanges: 0,
+      idleTimeoutForInitialStore: 0,
       cacheDirectory:
         opts.cache.cacheDirectory ||
         // 使用 rootDir 是在有 APP_ROOT 时，把 cache 目录放在根目录下

--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -51,6 +51,14 @@ export class DepInfo {
     }
   }
 
+  touchCache() {
+    if (existsSync(this.cacheFilePath)) {
+      const now = new Date();
+      fsExtra.utimesSync(this.cacheFilePath, now, now);
+      return;
+    }
+  }
+
   writeCache() {
     fsExtra.mkdirpSync(dirname(this.cacheFilePath));
     const newContent = JSON.stringify(
@@ -65,6 +73,8 @@ export class DepInfo {
       existsSync(this.cacheFilePath) &&
       readFileSync(this.cacheFilePath, 'utf-8') === newContent
     ) {
+      const now = new Date();
+      fsExtra.utimesSync(this.cacheFilePath, now, now);
       return;
     }
 

--- a/packages/mfsu/src/mfsu.ts
+++ b/packages/mfsu/src/mfsu.ts
@@ -243,6 +243,7 @@ promise new Promise(resolve => {
     const shouldBuild = this.depInfo.shouldBuild();
     if (!shouldBuild) {
       logger.info('MFSU skip buildDeps');
+      this.depInfo.touchCache();
       return;
     }
     this.depInfo.snapshot();


### PR DESCRIPTION
计划使用缓存 mtime 时间来决定是否要删除 webpack 的缓存。
如果 webpack 的缓存时间早于 msfu cache 时间，则让 webpack 缓存失效。
文件不存在时，mtime 记为 0，

如果都不存在，无操作
如果 webpack 缓存文件存在, mtime值为 m，mfsu 缓存 不存在，mtime 为 0， m>0,  失效 webpack 缓存
如果 webpack 缓存文件不存在，mtime 值为 0， mfsu缓存存在，无操作
如果 webpack 缓存文件存在，mtime 值为 t1， mfsu缓存存在 mtime 为 t2，如果 t1>t2 则 失效 webpack 缓存

目前遇到的问题，
首次启动 webpack 编译完成，done.hooks 通知 mfsu 的 depBuilder 构建，构建成功写入 mfsu_cache.json(t1),  done.hooks 同时触发 beginIdle 事件，开始 webpack 的缓存写入，写入时间 t2, t2 要比 t1 晚 4-5s。

如果用上面的方式来判断，缓存是否需要失效的，webpack 的缓存就应该失效。但是实际这种情况下缓存是有效的。