### PR TITLE
fix(plugins): access plugin initial state

### DIFF
--- a/packages/plugins/src/initial-state.ts
+++ b/packages/plugins/src/initial-state.ts
@@ -114,7 +114,7 @@ export default () => ({ loading: false, refresh: () => {} })
       content: `
 import React from 'react';
 import Provider from './Provider';
-export function innerProvider(container) {
+export function dataflowProvider(container) {
   return <Provider>{ container }</Provider>;
 }
       `,


### PR DESCRIPTION
## Decription

1. 修复 initial-state 的 provider 顺序导致的 access 初始化值为空的 bug
2. 允许开启 access 但不创建 `src/access.ts`