### PR TITLE
feat(plugin-docs): Add id attribute of page container and header title

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -44,7 +44,10 @@ export default (props: any) => {
         location: props.location,
       }}
     >
-      <div className="flex flex-col dark:bg-gray-900 min-h-screen transition-all">
+      <div
+        className="flex flex-col dark:bg-gray-900 min-h-screen transition-all"
+        id={isHomePage ? 'home-page' : 'doc-page'}
+      >
         <div
           id="head-container"
           className="z-30 sticky top-0 dark:before:bg-gray-800 before:bg-white before:bg-opacity-[.85]

--- a/packages/plugin-docs/client/theme-doc/Logo.tsx
+++ b/packages/plugin-docs/client/theme-doc/Logo.tsx
@@ -14,7 +14,10 @@ export default () => {
           <img src={Logo} className="w-8 h-8" alt="logo" />
         )}
         {typeof Logo === 'function' && <Logo />}
-        <div className="text-xl font-extrabold ml-2 dark:text-white">
+        <div
+          id="header-title"
+          className="text-xl font-extrabold ml-2 dark:text-white"
+        >
           {themeConfig.title}
         </div>
       </div>


### PR DESCRIPTION
帮 plugin-docs 加入了页面容器的 id 属性，并且能够感知是否为首页

<img width="456" alt="Screen Shot 2022-04-25 at 5 02 46 PM" src="https://user-images.githubusercontent.com/21105863/165056830-25a0846a-bf4c-44e2-901d-b4109ddb5ea9.png">

<img width="456" alt="Screen Shot 2022-04-25 at 5 03 45 PM" src="https://user-images.githubusercontent.com/21105863/165057001-dd415ef3-1d47-4d93-aa13-c40f40a2bacd.png">

帮顶部导航栏的 title 加入了 id 属性

<img width="456" alt="Screen Shot 2022-04-25 at 5 04 56 PM" src="https://user-images.githubusercontent.com/21105863/165057220-8bbdc63f-eeef-4649-9983-31ea24337c4e.png">

