### PR TITLE
fix(plugin-docs): Fix plugin search cannot find level 3 title bug

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -1,11 +1,13 @@
 import cx from 'classnames';
 import key from 'keymaster';
 import React, { Fragment, useEffect, useState } from 'react';
+import { Link } from 'umi';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
+import getLinkFromTitle from './utils/getLinkFromTitle';
 
 export default () => {
-  const { render } = useLanguage();
+  const { isFromPath, currentLanguage, render } = useLanguage();
   const [isFocused, setIsFocused] = useState(false);
   const [keyword, setKeyword] = useState('');
 
@@ -96,8 +98,8 @@ export default () => {
           )}
         >
           {result.map((r, i) => (
-            <a
-              href={r.href}
+            <Link
+              to={(isFromPath ? currentLanguage?.locale : '') + r.href}
               key={i}
               className="group outline-none search-result"
               onFocus={() => setIsFocused(true)}
@@ -109,7 +111,7 @@ export default () => {
               >
                 {r.path}
               </p>
-            </a>
+            </Link>
           ))}
         </div>
       </div>
@@ -127,9 +129,15 @@ function search(routes: any, keyword: string): SearchResultItem[] {
 
   const result: SearchResultItem[] = [];
 
+  function addResult(newResult: { path: string; href: string }) {
+    const { path, href } = newResult;
+    if (result.find((r) => r.path === path)) return;
+    result.push({ path, href });
+  }
+
   Object.keys(routes).map((path) => {
     if (path.toLowerCase().includes(keyword.toLowerCase())) {
-      result.push({
+      addResult({
         path: path.split('/').slice(1).join(' > '),
         href: '/' + path,
       });
@@ -137,16 +145,21 @@ function search(routes: any, keyword: string): SearchResultItem[] {
 
     const route = routes[path];
     if (!route.titles) return;
-    route.titles
-      .filter((t: any) => t.level <= 2)
-      .map((title: any) => {
-        if (title.title.toLowerCase().includes(keyword.toLowerCase())) {
-          result.push({
-            path: path.split('/').slice(1).join(' > ') + ' > ' + title.title,
-            href: '/' + path + '#' + title.title,
-          });
-        }
-      });
+    route.titles.map((title: any) => {
+      if (title.title.toLowerCase().includes(keyword.toLowerCase())) {
+        addResult({
+          path:
+            path
+              .split('/')
+              .map((s) => s.replace(/\.[a-z]{2}-[A-Z]{2}\/?/g, ''))
+              .slice(1)
+              .join(' > ') +
+            ' > ' +
+            title.title,
+          href: '/' + path + '#' + getLinkFromTitle(title.title),
+        });
+      }
+    });
   });
 
   if (result.length > 8) return result.slice(0, 8);

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -76,6 +76,7 @@ export default () => {
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           value={keyword}
+          autoComplete="off"
           onChange={(e) => setKeyword(e.target.value)}
           id="search-input"
           className="w-full bg-transparent outline-none text-sm px-4 py-2"

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -1,12 +1,12 @@
 import cx from 'classnames';
 import key from 'keymaster';
 import React, { Fragment, useEffect, useState } from 'react';
-import { Link } from 'umi';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
 import getLinkFromTitle from './utils/getLinkFromTitle';
 
 export default () => {
+  const { components } = useThemeContext()!;
   const { isFromPath, currentLanguage, render } = useLanguage();
   const [isFocused, setIsFocused] = useState(false);
   const [keyword, setKeyword] = useState('');
@@ -99,7 +99,7 @@ export default () => {
           )}
         >
           {result.map((r, i) => (
-            <Link
+            <components.Link
               to={(isFromPath ? currentLanguage?.locale : '') + r.href}
               key={i}
               className="group outline-none search-result"
@@ -112,7 +112,7 @@ export default () => {
               >
                 {r.path}
               </p>
-            </Link>
+            </components.Link>
           ))}
         </div>
       </div>

--- a/packages/plugin-docs/client/theme-doc/Toc.tsx
+++ b/packages/plugin-docs/client/theme-doc/Toc.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useThemeContext } from './context';
 import useLanguage from './useLanguage';
-
-function getLinkFromTitle(title: string) {
-  return title
-    .toLowerCase()
-    .replace(/\s/g, '-')
-    .replace(/[（）()\\{},]/g, '');
-}
+import getLinkFromTitle from './utils/getLinkFromTitle';
 
 export default () => {
   const { location, appData, themeConfig } = useThemeContext()!;

--- a/packages/plugin-docs/client/theme-doc/utils/getLinkFromTitle.ts
+++ b/packages/plugin-docs/client/theme-doc/utils/getLinkFromTitle.ts
@@ -1,0 +1,6 @@
+export default function getLinkFromTitle(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/[（）()\\{},]/g, '');
+}


### PR DESCRIPTION
修复了 `plugin-docs` 搜索功能的几个问题：

### 1. 无法搜索到 3 级以下的标题

Before

<img width="1165" alt="Screen Shot 2022-04-27 at 11 18 34 AM" src="https://user-images.githubusercontent.com/21105863/165433309-20d01328-7efe-4ba2-9dcb-4d4521285b65.png">

After

<img width="1165" alt="Screen Shot 2022-04-27 at 11 19 40 AM" src="https://user-images.githubusercontent.com/21105863/165433329-e6664b68-a586-4e27-b042-937e19b816f1.png">

### 2. 相同内容，不同语言的版本重复出现在搜索结果的问题

Before

<img width="512" alt="Screen Shot 2022-04-27 at 11 20 25 AM" src="https://user-images.githubusercontent.com/21105863/165433454-3646f050-9aaa-4e53-ad9a-5174bf8677c3.png">

After

<img width="624" alt="Screen Shot 2022-04-27 at 11 20 55 AM" src="https://user-images.githubusercontent.com/21105863/165433877-5664dc8d-be8e-4382-a678-e0ca49568a5f.png">

### 3. 点击搜索结果但路由哈希错误导致不会滚动到正确位置

<img width="910" alt="Screen Shot 2022-04-27 at 11 27 21 AM" src="https://user-images.githubusercontent.com/21105863/165434030-b762a140-ff54-4d37-b65a-893c4e275502.png">

### 4. Chrome 点击会打开浏览器自带的 Autocomplete 

<img width="658" alt="Screen Shot 2022-04-27 at 11 17 48 AM" src="https://user-images.githubusercontent.com/21105863/165433827-5fe0a37b-2577-4940-8ded-d5d727ba9d34.png">


