### PR TITLE
fix(plugin-docs): Fix home page horizontal scroll bar bug

### DIFF
--- a/packages/plugin-docs/client/theme-doc/components/Features.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Features.tsx
@@ -8,7 +8,7 @@ function Features(
   props: PropsWithChildren<{ title?: string; subtitle?: string }>,
 ) {
   return (
-    <div className="w-screen py-36 features dark:features-dark min-h-screen">
+    <div className="w-full py-36 features dark:features-dark min-h-screen">
       {(props.title || props.subtitle) && (
         <div className="mb-24 px-4">
           {props.title && (


### PR DESCRIPTION
修复了 `plugin-docs` 因为 Mac 系统约定当外接鼠标时会保持显示滚动条，导致宽度变窄而出现横向滚动条的问题。

<img width="1912" alt="Screen Shot 2022-04-27 at 12 29 45 PM" src="https://user-images.githubusercontent.com/21105863/165441032-be86f29b-b64e-4fcb-ad55-39ef5cfcaae9.png">

