### PR TITLE
fix(plugin-docs): Fix firefox glossy background polyfill bug and add default locale

### DIFF
--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -29,7 +29,7 @@ export default () => {
     setExpanded((e) => !e);
   }
 
-  if (!currentLanguage || languages.length === 1) return;
+  if (!currentLanguage || languages.length === 1) return null;
 
   return (
     <div>

--- a/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/LangSwitch.tsx
@@ -17,7 +17,7 @@ export default () => {
   }
 
   function handleClick() {
-    if (!currentLanguage) return;
+    if (!currentLanguage || languages.length === 1) return;
     if (languages.length === 2) {
       switchLanguage(
         languages[0].locale === currentLanguage.locale
@@ -28,6 +28,8 @@ export default () => {
     }
     setExpanded((e) => !e);
   }
+
+  if (!currentLanguage || languages.length === 1) return;
 
   return (
     <div>

--- a/packages/plugin-docs/client/theme-doc/Layout.tsx
+++ b/packages/plugin-docs/client/theme-doc/Layout.tsx
@@ -20,7 +20,8 @@ export default (props: any) => {
 
     function updateBlur() {
       if (!offset || !blur) return;
-      blur.backgroundPosition = `0px ` + `${-window.scrollY + 100}px`;
+      blur.backgroundPosition =
+        `0px ` + `calc(var(--anchor-offset) + ${-window.scrollY + 64}px)`;
     }
 
     document.addEventListener('scroll', updateBlur, false), updateBlur();

--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -102,6 +102,7 @@ export default () => {
             <components.Link
               to={(isFromPath ? currentLanguage?.locale : '') + r.href}
               key={i}
+              onClick={() => (document.activeElement as HTMLElement)?.blur()}
               className="group outline-none search-result"
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}

--- a/packages/plugin-docs/client/theme-doc/components/Announcement.tsx
+++ b/packages/plugin-docs/client/theme-doc/components/Announcement.tsx
@@ -6,6 +6,7 @@ function Announcement() {
   const { themeConfig } = useThemeContext()!;
 
   if (!themeConfig.announcement) {
+    document.documentElement.style.setProperty('--anchor-offset', '0px');
     return null;
   }
 

--- a/packages/plugin-docs/client/theme-doc/firefox-polyfill.css
+++ b/packages/plugin-docs/client/theme-doc/firefox-polyfill.css
@@ -12,9 +12,9 @@
   .g-glossy-firefox-cover {
     display: block;
     position: fixed;
-    top: var(--anchor-offset);
+    top: 0;
     width: 100%;
-    height: 72px;
+    height: calc(var(--anchor-offset) + 72px);
     z-index: 22;
     background-color: white;
   }
@@ -23,8 +23,8 @@
     display: block;
     position: fixed;
     width: 100%;
-    top: var(--anchor-offset);
-    height: 72px;
+    top: 0;
+    height: calc(var(--anchor-offset) + 72px);
     z-index: 24;
     background: -moz-element(#article-body) no-repeat top;
     filter: blur(10px);

--- a/packages/plugin-docs/client/theme-doc/useLanguage.ts
+++ b/packages/plugin-docs/client/theme-doc/useLanguage.ts
@@ -57,7 +57,13 @@ function useLanguage(): useLanguageResult {
   }
 
   function render(key: string) {
-    if (!currentLanguage || !themeConfig.locales) return key;
+    if (!themeConfig.locales || Object.keys(themeConfig.locales).length === 0)
+      return key;
+    if (!currentLanguage) {
+      return (
+        themeConfig.locales[Object.keys(themeConfig.locales)[0]].key || key
+      );
+    }
     if (!themeConfig.locales[currentLanguage.locale]) return key;
     return themeConfig.locales[currentLanguage.locale][key] || key;
   }


### PR DESCRIPTION
1. 修复了 Firefox 的毛玻璃补丁在没有 Announcement 组件时错位的问题
2. 优化搜索体验：点击搜索结果后关闭下拉选单
3. 增加了默认语言的支持，让不使用多语言的用户也能自定义默认显示的文字