### PR TITLE
feat(bundler-webpack): add dropDebugger、dropConsole config

### DIFF
--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -18,6 +18,7 @@ export async function addCompressPlugin(opts: IOpts) {
   const { config, userConfig, env } = opts;
   const jsMinifier = userConfig.jsMinifier || JSMinifier.esbuild;
   const cssMinifier = userConfig.cssMinifier || CSSMinifier.esbuild;
+  const { dropConsole = false, dropDebugger = false } = userConfig;
 
   if (
     env === Env.development ||
@@ -31,19 +32,37 @@ export async function addCompressPlugin(opts: IOpts) {
 
   let minify: any;
   let terserOptions: IConfig['jsMinifierOptions'];
+
+  const compress = {
+    drop_console: dropConsole,
+    drop_debugger: dropDebugger,
+  };
+
   if (jsMinifier === JSMinifier.esbuild) {
     minify = TerserPlugin.esbuildMinify;
     terserOptions = {
       target: getEsBuildTarget({
         targets: userConfig.targets || {},
       }),
+      drop: [dropConsole && 'console', dropDebugger && 'debugger'].filter(
+        Boolean,
+      ),
     };
   } else if (jsMinifier === JSMinifier.terser) {
     minify = TerserPlugin.terserMinify;
+    terserOptions = {
+      compress,
+    };
   } else if (jsMinifier === JSMinifier.swc) {
     minify = TerserPlugin.swcMinify;
+    terserOptions = {
+      compress,
+    };
   } else if (jsMinifier === JSMinifier.uglifyJs) {
     minify = TerserPlugin.uglifyJsMinify;
+    terserOptions = {
+      compress,
+    };
   } else if (jsMinifier !== JSMinifier.none) {
     throw new Error(`Unsupported jsMinifier ${userConfig.jsMinifier}.`);
   }

--- a/packages/bundler-webpack/src/schema.test.ts
+++ b/packages/bundler-webpack/src/schema.test.ts
@@ -23,6 +23,8 @@ const config = {
   https: {},
   depTranspiler: 'esbuild',
   devtool: 'cheap-module-source-map',
+  dropConsole: true,
+  dropDebugger: true,
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -61,6 +61,8 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
       ),
     devtool: (Joi) =>
       Joi.alternatives().try(Joi.string().regex(DEVTOOL_REGEX), Joi.boolean()),
+    dropConsole: (Joi) => Joi.boolean(),
+    dropDebugger: (Joi) => Joi.boolean(),
     esm: (Joi) => Joi.object(),
     externals: (Joi) =>
       Joi.alternatives().try(Joi.object(), Joi.string(), Joi.func()),

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -62,6 +62,8 @@ export interface IConfig {
   depTranspiler?: Transpiler;
   devtool?: Config.DevTool;
   deadCode?: DeadCodeParams;
+  dropConsole?: boolean;
+  dropDebugger?: boolean;
   https?: HttpsServerOptions;
   externals?: WebpackConfig['externals'];
   esm?: { [key: string]: any };


### PR DESCRIPTION
bundler-webpack 包支持 dropDebugger 和 dropConsole 配置项，分别用于删除产物代码中的 debugger 和 console.xxx 语句。

swc 支持也 drop 操作，所以没有让它报错