### PR TITLE
build: 将 target 升到 es2019

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "strict": true,
     "skipLibCheck": true,
-    "target": "es2015",
+    "target": "es2019",
     "jsx": "react",
     "paths": {
       "umi": ["./packages/umi"],


### PR DESCRIPTION
umi 对 node 版本的要求为 14或以上。 结合这个网站 https://node.green/ ，可以发现 node14 及以上对 es 最新语法已经支持到了 es2019。

可以适当调整 target 值，以减少构建的包大小。