### PR TITLE
fix(plugins): to avoid use route data in qiankun

### DIFF
--- a/packages/plugins/libs/qiankun/master/common.ts
+++ b/packages/plugins/libs/qiankun/master/common.ts
@@ -48,6 +48,7 @@ export function patchMicroAppRoute(
   getMicroAppRouteComponent: (opts: {
     appName: string;
     base: string;
+    routePath: string;
     masterHistoryType: string;
     routeProps?: any;
   }) => string | ReactComponentElement<any>,
@@ -88,6 +89,7 @@ export function patchMicroAppRoute(
     const opts = {
       appName: microAppName,
       base,
+      routePath: route.path,
       masterHistoryType,
       routeProps,
     };

--- a/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
+++ b/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
@@ -1,22 +1,20 @@
 import React from 'react';
 import { MicroApp } from './MicroApp';
-import { useRouteData } from 'umi';
 
 export function getMicroAppRouteComponent(opts: {
   appName: string;
   base: string;
+  routePath: string;
   masterHistoryType: string;
   routeProps?: any;
 }) {
-  const { base, masterHistoryType, appName, routeProps } = opts;
+  const { base, masterHistoryType, appName, routeProps, routePath } = opts;
   const RouteComponent = () => {
-    const { route } = useRouteData();
-
     // 默认取静态配置的 base
     let umiConfigBase = base === '/' ? '' : base;
 
     // 拼接子应用挂载路由
-    let runtimeMatchedBase = umiConfigBase + route.path.replace('/*', '');
+    let runtimeMatchedBase = umiConfigBase + routePath.replace('/*', '');
 
     {{#dynamicRoot}}
     // @see https://github.com/umijs/umi/blob/master/packages/preset-built-in/src/plugins/commands/htmlUtils.ts#L102

--- a/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
+++ b/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
@@ -50,6 +50,7 @@ function patchMicroAppRouteComponent(routes: any[]) {
       const patchRoute = (route: any) => {
         patchMicroAppRoute(route, getMicroAppRouteComponent, {
           base,
+          routePath: route.path,
           masterHistoryType,
           routeBindingAlias,
         });

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -124,7 +124,8 @@ const { formatMessage } = useIntl();
         }
         if (menuItemProps.path && location.pathname !== menuItemProps.path) {
           return (
-            <Link to={menuItemProps.path} target={menuItemProps.target}>
+            // handle wildcard route path, for example /slave/* from qiankun
+            <Link to={menuItemProps.path.replace('/*', '')} target={menuItemProps.target}>
               {defaultDom}
             </Link>
           );

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -57,7 +57,7 @@ export default (api: IApi) => {
         );
         route.file = `(async () => {
           const { getMicroAppRouteComponent } = await import('@@/plugin-qiankun-master/getMicroAppRouteComponent');
-          return getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} })
+          return getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', routePath: '${route.path}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} })
         })()`;
       }
     });


### PR DESCRIPTION
## Description

1. 目前 `patchClientRoutes` 的路由缺少 context，在 qiankun 内避免使用 `useRouteData`
2. layout 插件侧边栏兼容通配符的路由路径