### PR TITLE
fix(plugin-docs): Fix hash anchor bug in Chrome

### DIFF
--- a/packages/plugin-docs/src/compiler.ts
+++ b/packages/plugin-docs/src/compiler.ts
@@ -46,6 +46,7 @@ function MDXContent(props = {}) {
 
   useEffect(() => {
     if (window.location.hash.length !== 0) {
+      // 为了右侧内容区能正常跳转
       const hash = decodeURIComponent(window.location.hash);
       setTimeout(() => {
         document.getElementById(hash.slice(1))?.scrollIntoView();

--- a/packages/plugin-docs/src/compiler.ts
+++ b/packages/plugin-docs/src/compiler.ts
@@ -46,8 +46,10 @@ function MDXContent(props = {}) {
 
   useEffect(() => {
     if (window.location.hash.length !== 0) {
-      const hash = window.location.hash;
-      document.getElementById(hash.slice(1))?.scrollIntoView();
+      const hash = decodeURIComponent(window.location.hash);
+      setTimeout(() => {
+        document.getElementById(hash.slice(1))?.scrollIntoView();
+      }, 100);
     } else {
       window.scrollTo(0, 0);
     }


### PR DESCRIPTION
修复当带着哈希值进入文档页面时，Chrome 浏览器无法自动滚动到对应位置的问题