### PR TITLE
Fix/ make generator disabled error message

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export * from './config/config';
 export * from './route/route';
-export { GeneratorType, IGeneratorOpts } from './service/generator';
+export { Generator, GeneratorType } from './service/generator';
 export * from './service/pluginAPI';
 export * from './service/service';
 export { Env, IAdd, IEvent, IModify, IRoute } from './types';

--- a/packages/core/src/service/generator.ts
+++ b/packages/core/src/service/generator.ts
@@ -6,14 +6,11 @@ export enum GeneratorType {
   enable = 'enable',
 }
 
-export interface IGeneratorOpts {
+type IGeneratorOptsWithoutEnableCheck = {
   key: string;
   name: string;
   description: string;
-  type?: GeneratorType;
-  checkEnable?: {
-    (opts: { args: any }): boolean;
-  };
+  type: GeneratorType.generate;
   fn: {
     (opts: {
       args: any;
@@ -33,24 +30,44 @@ export interface IGeneratorOpts {
     }): void;
   };
   plugin: Plugin;
-}
+};
 
-export class Generator {
-  key: IGeneratorOpts['key'];
-  name: IGeneratorOpts['name'];
-  description: IGeneratorOpts['description'];
-  type?: IGeneratorOpts['type'];
-  checkEnable?: IGeneratorOpts['checkEnable'];
-  fn: IGeneratorOpts['fn'];
-  plugin: IGeneratorOpts['plugin'];
+type IGeneratorOptsWithEnableCheck = {
+  key: string;
+  name: string;
+  description: string;
+  type: GeneratorType.enable;
+  checkEnable: {
+    (opts: { args: any }): boolean;
+  };
+  disabledDescription: string;
+  fn: {
+    (opts: {
+      args: any;
+      generateFile: typeof generateFile;
+      updatePackageJSON: {
+        (opts: { opts: object; cwd?: string }): void;
+      };
+      installDeps: {
+        (opts: {
+          opts: {
+            devDependencies?: string[];
+            dependencies?: string[];
+          };
+          cwd?: string;
+        }): void;
+      };
+    }): void;
+  };
+  plugin: Plugin;
+};
 
-  constructor(opts: IGeneratorOpts) {
-    this.key = opts.key;
-    this.name = opts.name;
-    this.type = opts.type;
-    this.description = opts.description;
-    this.checkEnable = opts.checkEnable;
-    this.fn = opts.fn;
-    this.plugin = opts.plugin;
-  }
+export type Generator =
+  | IGeneratorOptsWithEnableCheck
+  | IGeneratorOptsWithoutEnableCheck;
+
+export function makeGenerator<T>(opts: T): T {
+  return {
+    ...opts,
+  };
 }

--- a/packages/preset-umi/src/commands/generators/api.ts
+++ b/packages/preset-umi/src/commands/generators/api.ts
@@ -1,3 +1,4 @@
+import { GeneratorType } from '@umijs/core';
 import { lodash } from '@umijs/utils';
 import { join, parse } from 'path';
 import { TEMPLATES_DIR } from '../../constants';
@@ -13,6 +14,7 @@ export default (api: IApi) => {
     key: 'api',
     name: 'Generator api',
     description: 'Generate api route boilerplate code',
+    type: GeneratorType.generate,
     async fn(opts) {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/dva.ts
+++ b/packages/preset-umi/src/commands/generators/dva.ts
@@ -17,6 +17,7 @@ export default (api: IApi) => {
     checkEnable: () => {
       return !api.config.dva;
     },
+    disabledDescription: `dva has been enabled; you can remove \`dva\` field in ${api.appData.mainConfigFile} then run this again to re-setup.`,
     fn: async () => {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/jest.ts
+++ b/packages/preset-umi/src/commands/generators/jest.ts
@@ -21,6 +21,8 @@ export default (api: IApi) => {
         !existsSync(join(api.paths.cwd, 'jest.config.js'))
       );
     },
+    disabledDescription:
+      'jest has already enabled. You can remove jest.config.{ts,js}, then run this again to re-setup.',
     fn: async () => {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/prettier.ts
+++ b/packages/preset-umi/src/commands/generators/prettier.ts
@@ -19,6 +19,8 @@ export default (api: IApi) => {
       // 存在 .prettierrc，不开启
       return !existsSync(join(api.cwd, '.prettierrc'));
     },
+    disabledDescription:
+      'prettier has been enabled; You can remove `.prettierrc` to run this again to re-setup.',
     fn: async () => {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/tailwindcss.ts
+++ b/packages/preset-umi/src/commands/generators/tailwindcss.ts
@@ -18,6 +18,7 @@ export default (api: IApi) => {
     checkEnable: () => {
       return !api.config.tailwindcss;
     },
+    disabledDescription: `tailwindcss has been enabled; you can remove \`tailwindcss\` fields in ${api.appData.mainConfigFile} then run this to re-setup`,
     fn: async () => {
       const h = new GeneratorHelper(api);
 

--- a/packages/preset-umi/src/commands/generators/tsconfig.ts
+++ b/packages/preset-umi/src/commands/generators/tsconfig.ts
@@ -18,6 +18,8 @@ export default (api: IApi) => {
     checkEnable: () => {
       return !existsSync(join(api.paths.cwd, 'tsconfig.json'));
     },
+    disabledDescription:
+      'tsconfig has been enabled; you can remove tsconfig.json then run this again to re-setup',
     fn: async () => {
       const h = new GeneratorHelper(api);
 


### PR DESCRIPTION
```bash
(ins)$u g jest
info  - @local
✔ Will you use @testing-library/react for UI testing?! … no
info  - Write package.json
warn  - scripts.test already exists, skip update
info  - Write jest.config.ts
Lockfile is up-to-date, resolution step is skipped
Already up-to-date
info  - Install dependencies with pnpm
(ins)$u g jest
info  - @local
warn  - jest has already enabled. You can remove jest.config.{ts,js}, then run this again to re-setup.
```