### PR TITLE
fix(plugins): do not replace externalized dep to abs path in tmp file

### DIFF
--- a/packages/plugins/src/model.ts
+++ b/packages/plugins/src/model.ts
@@ -2,8 +2,8 @@ import * as t from '@umijs/bundler-utils/compiled/babel/types';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi';
-import { winPath } from 'umi/plugin-utils';
 import { ModelUtils } from './utils/modelUtils';
+import { replaceDepToAbsPath } from './utils/tplUtils';
 import { withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
@@ -31,10 +31,14 @@ export default (api: IApi) => {
     const indexContent = readFileSync(
       join(__dirname, '../libs/model.tsx'),
       'utf-8',
-    ).replace('fast-deep-equal', winPath(require.resolve('fast-deep-equal')));
+    );
     api.writeTmpFile({
       path: 'index.tsx',
-      content: indexContent,
+      content: replaceDepToAbsPath(
+        indexContent,
+        ['fast-deep-equal'],
+        api.config.externals,
+      ),
     });
 
     // runtime.tsx

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { IApi } from 'umi';
-import { winPath } from 'umi/plugin-utils';
+import { replaceDepToAbsPath } from '../utils/tplUtils';
 import { withTmpPath } from '../utils/withTmpPath';
 import {
   defaultHistoryType,
@@ -130,21 +130,16 @@ export const setMasterOptions = (newOpts) => options = ({ ...options, ...newOpts
       } else {
         api.writeTmpFile({
           path: file.replace(/\.tpl$/, ''),
-          content: getFileContent(file)
-            .replace(
+          content: replaceDepToAbsPath(
+            getFileContent(file).replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
                 ? `import { useModel } from '@@/plugin-model'`
                 : `const useModel = null;`,
-            )
-            .replace(
-              /from 'qiankun'/g,
-              `from '${winPath(dirname(require.resolve('qiankun/package')))}'`,
-            )
-            .replace(
-              /from 'lodash\//g,
-              `from '${winPath(dirname(require.resolve('lodash/package')))}/`,
             ),
+            ['qiankun', 'lodash'],
+            api.config.externals,
+          ),
         });
       }
     });

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { readFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { IApi } from 'umi';
-import { winPath } from 'umi/plugin-utils';
+import { replaceDepToAbsPath } from '../utils/tplUtils';
 import { withTmpPath } from '../utils/withTmpPath';
 import { qiankunStateFromMasterModelNamespace } from './constants';
 
@@ -168,21 +168,16 @@ if (!window.__POWERED_BY_QIANKUN__) {
       ].forEach((file) => {
         api.writeTmpFile({
           path: file.replace(/\.tpl$/, ''),
-          content: getFileContent(file)
-            .replace(
+          content: replaceDepToAbsPath(
+            getFileContent(file).replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
                 ? `import { useModel } from '@@/plugin-model'`
                 : `const useModel = null;`,
-            )
-            .replace(
-              /from 'qiankun'/g,
-              `from '${winPath(dirname(require.resolve('qiankun/package')))}'`,
-            )
-            .replace(
-              /from 'lodash\//g,
-              `from '${winPath(dirname(require.resolve('lodash/package')))}/`,
             ),
+            ['qiankun', 'lodash'],
+            api.config.externals,
+          ),
         });
       });
 

--- a/packages/plugins/src/utils/tplUtils.test.ts
+++ b/packages/plugins/src/utils/tplUtils.test.ts
@@ -1,0 +1,30 @@
+import { replaceDepToAbsPath } from './tplUtils';
+
+test('replace full dep import to abs path', () => {
+  const content = "import a from 'fast-deep-equal'";
+
+  expect(replaceDepToAbsPath(content, ['fast-deep-equal'], {})).not.toContain(
+    "'fast-deep-equal'",
+  );
+});
+
+test('skip replace for externalized dep', () => {
+  const content = "import a from 'fast-deep-equal'";
+
+  expect(
+    replaceDepToAbsPath(content, ['fast-deep-equal'], { 'fast-deep-equal': 1 }),
+  ).toContain("'fast-deep-equal'");
+});
+
+test('only replace subpath for exact match externalized dep', () => {
+  const content = `
+import a from 'fast-deep-equal';
+import b from 'fast-deep-equal/lib/index';
+`;
+  const result = replaceDepToAbsPath(content, ['fast-deep-equal'], {
+    'fast-deep-equal$': 1,
+  });
+
+  expect(result).toContain("'fast-deep-equal'");
+  expect(result).not.toContain("'fast-deep-equal/lib/index'");
+});

--- a/packages/plugins/src/utils/tplUtils.ts
+++ b/packages/plugins/src/utils/tplUtils.ts
@@ -1,0 +1,35 @@
+import { dirname } from 'path';
+import { winPath } from 'umi/plugin-utils';
+
+/**
+ * replace dependencies import which not be externalized with absolute path
+ */
+export function replaceDepToAbsPath(
+  content: string,
+  deps: string[],
+  externals: Record<string, any> = {},
+) {
+  const externalDeps = Object.keys(externals);
+
+  // filter externalized deps, but exclude exact match (e.g. 'react$')
+  deps
+    .filter((dep) => !externalDeps.includes(dep))
+    .forEach((dep) => {
+      let regexp: RegExp;
+
+      if (externals[`${dep}$`]) {
+        // only replace subpath import if dep is exact match external
+        regexp = new RegExp(`from '${dep}(/)`, 'g');
+      } else {
+        // otherwise, replace all path import
+        regexp = new RegExp(`from '${dep}(/|')`, 'g');
+      }
+
+      content = content.replace(
+        regexp,
+        `from '${winPath(dirname(require.resolve(`${dep}/package`)))}$1`,
+      );
+    });
+
+  return content;
+}


### PR DESCRIPTION
## Description

不对临时文件中已被 externals 的依赖做绝对路径转换，避免 externals 配置无法命中导致多实例的问题。

例如：qiankun 插件的临时文件通过绝对路径引入了 qiankun、导致其他地方无法通过 externals 配置项控制插件内部的 qiankun 的引入，最终引起多实例问题