### PR TITLE
fix(plugins): allow control import for qiankun external

### DIFF
--- a/packages/plugins/src/qiankun.ts
+++ b/packages/plugins/src/qiankun.ts
@@ -7,6 +7,7 @@ export default (api: IApi) => {
         return joi.object().keys({
           slave: joi.object(),
           master: joi.object(),
+          externalQiankun: joi.boolean(),
         });
       },
     },

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -128,18 +128,23 @@ export const setMasterOptions = (newOpts) => options = ({ ...options, ...newOpts
           },
         });
       } else {
+        let content = getFileContent(file);
+
+        if (!api.config.qiankun.externalQiankun) {
+          content = content.replace(
+            /from 'qiankun'/g,
+            `from '${winPath(dirname(require.resolve('qiankun/package')))}'`,
+          );
+        }
+
         api.writeTmpFile({
           path: file.replace(/\.tpl$/, ''),
-          content: getFileContent(file)
+          content: content
             .replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
                 ? `import { useModel } from '@@/plugin-model'`
                 : `const useModel = null;`,
-            )
-            .replace(
-              /from 'qiankun'/g,
-              `from '${winPath(dirname(require.resolve('qiankun/package')))}'`,
             )
             .replace(
               /from 'lodash\//g,


### PR DESCRIPTION
## Description

qiankun 插件配置项增加 `externalQiankun`，控制 qiankun 依赖是否以绝对路径引入，解 qiankun external 不生效的问题。

ref: #744 