### PR TITLE
feat(preset-umi): routes config change type is modified to regenerateTmpFiles

### DIFF
--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -72,6 +72,12 @@ export default (api: IApi) => {
     if (key in configDefaults) {
       config.default = configDefaults[key];
     }
+
+    // change type is regenerateTmpFiles
+    if (['routes'].includes(key)) {
+      config.onChange = api.ConfigChangeType.regenerateTmpFiles;
+    }
+
     api.registerPlugins([
       {
         id: `virtual: config-${key}`,


### PR DESCRIPTION
`routes` onChange type 修改为只重新生成临时文件, 不在重启进程