### PR TITLE
Feat/terminal move to .umi/core/terminal.ts

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -9,7 +9,7 @@
 创建使用浏览器内置 `history` 来跟踪应用的 `BrowserHistory`。推荐在支持 HTML5 `history` 接口的 现代 Web 浏览器中使用。
 
 类型定义如下：
-```typescript
+```ts
 function createBrowserHistory(options?: { window?: Window }) => BrowserHistory;
 ```
 
@@ -286,6 +286,20 @@ function Dashboard() {
   return <div><h1>Dashboard</h1><Outlet /></div>;
 }
 ```
+
+### terminal 
+
+`terminal` 用于在开发阶段在浏览器向 node 终端输出日志的工具。
+
+示例：
+```ts
+import {terminal} from 'umi';
+// 下面三条命令会在 umi 启动终端上打出用不同颜色代表的日志
+terminal.log('i am log level');
+terminal.warn('i am warn level');
+terminal.error('i am error level');
+```
+注意 `terminal` 只在环境变量 `NODE_ENV` 非 `production` 时生效；在 Umi 的构建产物中对应的日志调用函数不会有任何作用，所以可以不必删除对 `terminal` 的代码。
 
 ### useAppData
 

--- a/packages/create-umi/templates/app/.gitignore.tpl
+++ b/packages/create-umi/templates/app/.gitignore.tpl
@@ -6,5 +6,6 @@
 /src/.umi-production
 /.umi
 /.umi-production
+/.umi-test
 /dist
 /.mfsu

--- a/packages/preset-umi/src/features/terminal/terminal.ts
+++ b/packages/preset-umi/src/features/terminal/terminal.ts
@@ -15,14 +15,19 @@ export default (api: IApi) => {
     // ref:
     // https://github.com/patak-dev/vite-plugin-terminal/blob/main/src/index.ts
     api.writeTmpFile({
-      path: 'index.ts',
+      path: 'core/terminal.ts',
+      noPluginDir: true,
       content: `
 const console = globalThis.console;
 let count = 0;
 let groupLevel = 0;
 function send(type: string, message?: string) {
-  const encodedMessage = message ? \`&m=\${encodeURI(message)}\` : '';
-  fetch(\`/__umi/api/terminal?type=\${type}&t=\${Date.now()}&c=\${count++}&g=\${groupLevel}\${encodedMessage}\`, { mode: 'no-cors' })
+  if(process.env.NODE_ENV==='production'){
+    return;
+  }else{
+    const encodedMessage = message ? \`&m=\${encodeURI(message)}\` : '';
+    fetch(\`/__umi/api/terminal?type=\${type}&t=\${Date.now()}&c=\${count++}&g=\${groupLevel}\${encodedMessage}\`, { mode: 'no-cors' })
+  }
 }
 function prettyPrint(obj: any) {
   return JSON.stringify(obj, null, 2);

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -263,6 +263,15 @@ export default function EmptyRoute() {
         exportMembers,
         path: '@@/core/history.ts',
       });
+      // @@/core/terminal.ts
+      if (api.service.config.terminal !== false) {
+        exports.push(`export { terminal } from './core/terminal';`);
+        checkMembers({
+          members: ['terminal'],
+          exportMembers,
+          path: '@@/core/terminal.ts',
+        });
+      }
       // plugins
       exports.push('// plugins');
       const plugins = readdirSync(api.paths.absTmpPath).filter((file) => {


### PR DESCRIPTION
可能的风险是，已经生成的 plugin-terminal 会和 core/terminal.ts 
需要用户手动删除 .umi 文件夹 解决。