### PR TITLE
fix(route-prefetch): support publicPath and runtimePublicPath

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -1,4 +1,6 @@
 export default {
   mfsu: false,
+  routePrefetch: {},
+  manifest: {},
   plugins: ['@umijs/plugin-docs'],
 };

--- a/packages/plugin-docs/client/theme-doc/Sidebar.tsx
+++ b/packages/plugin-docs/client/theme-doc/Sidebar.tsx
@@ -63,7 +63,8 @@ export default (props: SidebarProps) => {
                 return (
                   <components.Link
                     key={route.path}
-                    to={route.path}
+                    to={to.startsWith('/') ? to : `/${to}`}
+                    prefetch
                     onClick={() =>
                       props.setMenuOpened && props.setMenuOpened((o) => !o)
                     }

--- a/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
+++ b/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
@@ -28,7 +28,7 @@ export default (api: IApi) => {
     );
     const manifestObj = JSON.parse(manifest);
     const umiJsFileKey = Object.keys(manifestObj).find((key) =>
-      key.startsWith('umi.'),
+      key.match(/^umi(.*)\.js$/),
     );
     if (!umiJsFileKey) {
       throw new Error('Cannot find umi.js in manifest.json');

--- a/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
+++ b/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
@@ -34,7 +34,11 @@ export default (api: IApi) => {
       throw new Error('Cannot find umi.js in manifest.json');
     }
 
-    const umiJsFileName = manifestObj[umiJsFileKey];
+    // manifest has publicPath, but we don't need it in the absOutputPath
+    const umiJsFileName = manifestObj[umiJsFileKey].replace(
+      new RegExp('^' + api.config.publicPath),
+      '',
+    );
     const umiJsFile = readFileSync(
       join(api.paths.absOutputPath, umiJsFileName),
       'utf-8',

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -35,6 +35,8 @@ export default (api: IApi) => {
       context: {
         mountElementId: api.config.mountElementId,
         rendererPath,
+        publicPath: api.config.publicPath,
+        runtimePublicPath: api.config.runtimePublicPath ? 'true' : 'false',
         entryCode: (
           await api.applyPlugins({
             key: 'addEntryCode',

--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -10,6 +10,9 @@ import Loading from '@/loading';
 import { ApplyPluginsType } from 'umi';
 {{{ imports }}}
 
+const publicPath = "{{{ publicPath }}}";
+const runtimePublicPath = {{{ runtimePublicPath }}};
+
 async function render() {
   const pluginManager = createPluginManager();
   const { routes, routeComponents } = await getRoutes(pluginManager);
@@ -42,6 +45,8 @@ async function render() {
 {{#loadingComponent}}
         loadingComponent: Loading,
 {{/loadingComponent}}
+        publicPath,
+        runtimePublicPath,
         history: createHistory({
           type: '{{{ historyType }}}',
           basename,

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -54,6 +54,8 @@ function Routes() {
 }
 
 export function renderClient(opts: {
+  publicPath?: string;
+  runtimePublicPath?: boolean;
   rootElement?: HTMLElement;
   routes: IRoutesById;
   routeComponents: IRouteComponents;
@@ -126,12 +128,20 @@ export function renderClient(opts: {
                 k.startsWith(routeIdReplaced + '.'),
               );
               if (!key) return;
-              const file = manifest[key];
+              let file = manifest[key];
               const link = document.createElement('link');
               link.id = preloadId;
               link.rel = 'preload';
               link.as = 'script';
-              // TODO: public path may not be root
+              // publicPath already in the manifest,
+              // but if runtimePublicPath is true, we need to replace it
+              if (opts.runtimePublicPath) {
+                // @ts-ignore
+                file = file.replace(
+                  new RegExp(`^${opts.publicPath}`),
+                  window.publicPath,
+                );
+              }
               link.href = file;
               document.head.appendChild(link);
             }

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -136,9 +136,9 @@ export function renderClient(opts: {
               // publicPath already in the manifest,
               // but if runtimePublicPath is true, we need to replace it
               if (opts.runtimePublicPath) {
-                // @ts-ignore
                 file = file.replace(
                   new RegExp(`^${opts.publicPath}`),
+                  // @ts-ignore
                   window.publicPath,
                 );
               }


### PR DESCRIPTION
1. 修复了在设置了 `publicPath` 或 `runtimePublicPath` 下，路由组件预加载的路径问题。
2. 如果用户配置了 `publicPath` ，这个路径会被加入到 `asset-manifest.json` 文件中所有资源的路径前面，因此运行时动态加载不需要做额外处理。但在打包时要把 `asset-manifest.json` 注入 `umi.js` 前面的时候，需要将 `umi.js` 文件名开头的 `publicPath` 给移除。
3. 如果用户配置了 `runtimePublicPath`，则运行时动态加载路由组件时要把 manifest 中静态资源路径开头的 `publicPath` 替换为 `window.publicPath`。
4. 修复了可能会把 manifest 注入到 umi.css 而不是 umi.js 的问题
5. 在 umi 官网启用了 route prefetch

