### PR TITLE
fix(route-prefetch): Use webpack plugin to inject manifest

### DIFF
--- a/examples/client-loader/package.json
+++ b/examples/client-loader/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "express": "4.17.3",
-    "umi": "4.0.0-rc.17"
+    "umi": "4.0.0-canary.20220517.1"
   }
 }

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -44,7 +44,8 @@
     "react-dom": "18.1.0",
     "react-router": "6.3.0",
     "react-router-dom": "6.3.0",
-    "regenerator-runtime": "0.13.9"
+    "regenerator-runtime": "0.13.9",
+    "webpack-sources": "3.2.3"
   },
   "devDependencies": {
     "@manypkg/get-packages": "1.1.3",

--- a/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
+++ b/packages/preset-umi/src/features/routePrefetch/routePrefetch.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { webpack } from '@umijs/bundler-webpack';
+import { RawSource } from 'webpack-sources';
 import type { IApi } from '../../types';
 
 export default (api: IApi) => {
@@ -18,37 +18,43 @@ export default (api: IApi) => {
     }
   });
 
-  api.onBuildComplete(() => {
-    const manifest = readFileSync(
-      join(
-        api.paths.absOutputPath,
-        api.config.manifest.fileName || 'asset-manifest.json',
-      ),
-      'utf-8',
-    );
-    const manifestObj = JSON.parse(manifest);
-    const umiJsFileKey = Object.keys(manifestObj).find((key) =>
-      key.match(/^umi(.*)\.js$/),
-    );
-    if (!umiJsFileKey) {
-      throw new Error('Cannot find umi.js in manifest.json');
-    }
-
-    // manifest has publicPath, but we don't need it in the absOutputPath
-    const umiJsFileName = manifestObj[umiJsFileKey].replace(
-      new RegExp('^' + api.config.publicPath),
-      '',
-    );
-    const umiJsFile = readFileSync(
-      join(api.paths.absOutputPath, umiJsFileName),
-      'utf-8',
-    );
-
-    // TODO: source map will break if we append to the beginning of the file, use https://github.com/Rich-Harris/magic-string to fix this
-    const prependJS = `window.__umi_manifest__ = ` + manifest + ';';
-    writeFileSync(
-      join(api.paths.absOutputPath, umiJsFileName),
-      prependJS + umiJsFile,
-    );
+  api.chainWebpack((memo) => {
+    memo.plugin('manifest-inject-plugin').use(WebpackAssetsInjectPlugin, [api]);
   });
 };
+
+class WebpackAssetsInjectPlugin {
+  api: IApi;
+
+  constructor(api: IApi) {
+    this.api = api;
+  }
+
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.compilation.tap(
+      'WebpackAssetsInjectPlugin',
+      (compilation) => {
+        compilation.hooks.afterProcessAssets.tap(
+          'WebpackAssetsInjectPlugin',
+          (a) => {
+            const manifestKey = Object.keys(a).find(
+              (key) =>
+                key === this.api.config.manifest.fileName ||
+                key === 'asset-manifest.json',
+            );
+            const umiJsKey = Object.keys(a).find((key) =>
+              key.match(/^umi(.*).js$/),
+            );
+            if (!manifestKey || !umiJsKey) return;
+            const newUmiJsString =
+              `window.__umi_manifest__ = ${a[manifestKey].source()};` +
+              a[umiJsKey].source();
+            compilation.deleteAsset(umiJsKey);
+            // @ts-ignore
+            compilation.emitAsset(umiJsKey, new RawSource(newUmiJsString));
+          },
+        );
+      },
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,10 +195,10 @@ importers:
   examples/client-loader:
     specifiers:
       express: 4.17.3
-      umi: 4.0.0-rc.17
+      umi: 4.0.0-canary.20220517.1
     dependencies:
       express: 4.17.3
-      umi: 4.0.0-rc.17_73ef0f7440095af8fd8f18171da41351
+      umi: link:../../packages/umi
 
   examples/diff-client-loader:
     specifiers:
@@ -1034,6 +1034,7 @@ importers:
       regenerator-runtime: 0.13.9
       sirv: 2.0.2
       vite: 2.9.1
+      webpack-sources: 3.2.3
     dependencies:
       '@types/multer': 1.4.7
       '@umijs/ast': link:../ast
@@ -1055,6 +1056,7 @@ importers:
       react-router: 6.3.0_react@18.1.0
       react-router-dom: 6.3.0_react-dom@18.1.0+react@18.1.0
       regenerator-runtime: 0.13.9
+      webpack-sources: 3.2.3
     devDependencies:
       '@manypkg/get-packages': 1.1.3
       '@types/body-parser': 1.19.2
@@ -26316,7 +26318,6 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
 
   /webpack-virtual-modules/0.4.3:
     resolution: {integrity: sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==}


### PR DESCRIPTION
把 route-preload 需要的 manifest 注入到 umi.js 这个步骤从原本的 `api.onBuildComplete` 移到了 Webpack Plugin 内部进行