### PR TITLE
chore: avoid local path mix in outputs

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -120,7 +120,7 @@ export async function getRoutes(opts: { api: IApi }) {
     initialValue: [
       existsSync(absLayoutPath) && {
         id: '@@/global-layout',
-        file: absLayoutPath,
+        file: `@/layouts/index.tsx`,
       },
     ].filter(Boolean),
   });

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -114,15 +114,22 @@ export async function getRoutes(opts: { api: IApi }) {
   }
 
   // layout routes
-  const absLayoutPath = join(opts.api.paths.absSrcPath, 'layouts/index.tsx');
-  const layouts = await opts.api.applyPlugins({
-    key: 'addLayouts',
-    initialValue: [
-      existsSync(absLayoutPath) && {
-        id: '@@/global-layout',
-        file: `@/layouts/index.tsx`,
-      },
-    ].filter(Boolean),
+  const absSrcPath = opts.api.paths.absSrcPath;
+  const absLayoutPath = join(absSrcPath, 'layouts/index.tsx');
+  const layouts = (
+    await opts.api.applyPlugins({
+      key: 'addLayouts',
+      initialValue: [
+        existsSync(absLayoutPath) && {
+          id: '@@/global-layout',
+          file: absLayoutPath,
+        },
+      ].filter(Boolean),
+    })
+  ).map((layout: { file: string }) => {
+    // prune local path prefix, avoid mix in outputs
+    layout.file = layout.file.replace(new RegExp(`^${absSrcPath}`), '@');
+    return layout;
   });
   for (const layout of layouts) {
     addParentRoute({

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -122,7 +122,7 @@ export async function getRoutes(opts: { api: IApi }) {
       initialValue: [
         existsSync(absLayoutPath) && {
           id: '@@/global-layout',
-          file: absLayoutPath,
+          file: winPath(absLayoutPath),
         },
       ].filter(Boolean),
     })

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -114,22 +114,15 @@ export async function getRoutes(opts: { api: IApi }) {
   }
 
   // layout routes
-  const absSrcPath = opts.api.paths.absSrcPath;
-  const absLayoutPath = join(absSrcPath, 'layouts/index.tsx');
-  const layouts = (
-    await opts.api.applyPlugins({
-      key: 'addLayouts',
-      initialValue: [
-        existsSync(absLayoutPath) && {
-          id: '@@/global-layout',
-          file: absLayoutPath,
-        },
-      ].filter(Boolean),
-    })
-  ).map((layout: { file: string }) => {
-    // prune local path prefix, avoid mix in outputs
-    layout.file = layout.file.replace(new RegExp(`^${absSrcPath}`), '@');
-    return layout;
+  const absLayoutPath = join(opts.api.paths.absSrcPath, 'layouts/index.tsx');
+  const layouts = await opts.api.applyPlugins({
+    key: 'addLayouts',
+    initialValue: [
+      existsSync(absLayoutPath) && {
+        id: '@@/global-layout',
+        file: absLayoutPath,
+      },
+    ].filter(Boolean),
   });
   for (const layout of layouts) {
     addParentRoute({
@@ -189,10 +182,18 @@ export async function getRouteComponents(opts: {
         return `'${key}': () => Promise.resolve(${route.file}),`;
       }
 
-      const path =
-        isAbsolute(route.file) || route.file.startsWith('@/')
-          ? route.file
-          : `${opts.prefix}${route.file}`;
+      let path: string;
+      if (isAbsolute(route.file)) {
+        // prune local path prefix, avoid mix in outputs
+        path = route.file.replace(
+          new RegExp(`^${opts.api.paths.absSrcPath}`),
+          '@',
+        );
+      } else if (route.file.startsWith('@/')) {
+        path = route.file;
+      } else {
+        path = `${opts.prefix}${route.file}`;
+      }
 
       return `'${key}': () => import(/* webpackChunkName: "${key.replace(
         /[\/-]/g,

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -1,4 +1,4 @@
-import { lodash, winPath } from '@umijs/utils';
+import { lodash, tryPaths, winPath } from '@umijs/utils';
 import { existsSync, readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { TEMPLATES_DIR } from '../../constants';
@@ -138,18 +138,13 @@ export default function EmptyRoute() {
     const plugins: string[] = await api.applyPlugins({
       key: 'addRuntimePlugin',
       initialValue: [
-        // TODO: add tryFiles in @umijs/utils
-        existsSync(join(api.paths.absSrcPath, 'app.ts')) &&
+        tryPaths([
           join(api.paths.absSrcPath, 'app.ts'),
-        existsSync(join(api.paths.absSrcPath, 'app.tsx')) &&
           join(api.paths.absSrcPath, 'app.tsx'),
-        existsSync(join(api.paths.absSrcPath, 'app.jsx')) &&
           join(api.paths.absSrcPath, 'app.jsx'),
-        existsSync(join(api.paths.absSrcPath, 'app.js')) &&
           join(api.paths.absSrcPath, 'app.js'),
-      ]
-        .filter(Boolean)
-        .slice(0, 1),
+        ]),
+      ].filter(Boolean),
     });
     const validKeys = await api.applyPlugins({
       key: 'addRuntimePluginKey',

--- a/packages/preset-umi/templates/plugin.tpl
+++ b/packages/preset-umi/templates/plugin.tpl
@@ -8,7 +8,7 @@ export function getPlugins() {
 {{#plugins}}
     {
       apply: Plugin_{{{ index }}},
-      path: '{{{ path }}}',
+      path: process.env.NODE_ENV === 'production' ? void 0 : '{{{ path }}}',
     },
 {{/plugins}}
   ];

--- a/packages/umi/client/client/plugin.js
+++ b/packages/umi/client/client/plugin.js
@@ -59,9 +59,9 @@ var PluginManager = /** @class */ (function () {
     }
     PluginManager.prototype.register = function (plugin) {
         var _this = this;
-        assert(plugin.apply && plugin.path, "plugin register failed, apply and path must supplied");
+        assert(plugin.apply, "plugin register failed, apply must supplied");
         Object.keys(plugin.apply).forEach(function (key) {
-            assert(_this.opts.validKeys.indexOf(key) > -1, "register failed, invalid key ".concat(key, " from plugin ").concat(plugin.path, "."));
+            assert(_this.opts.validKeys.indexOf(key) > -1, "register failed, invalid key ".concat(key, " ").concat(plugin.path ? "from plugin ".concat(plugin.path) : '', "."));
             _this.hooks[key] = (_this.hooks[key] || []).concat(plugin.apply[key]);
         });
     };

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -34,6 +34,7 @@
     "build:client": "pnpm tsc --project ./tsconfig.client.json",
     "build:deps": "umi-scripts bundleDeps",
     "dev": "pnpm build -- --watch",
+    "dev:client": "pnpm build:client -- --watch",
     "test": "umi-scripts jest-turbo"
   },
   "dependencies": {

--- a/packages/umi/src/client/plugin.ts
+++ b/packages/umi/src/client/plugin.ts
@@ -21,14 +21,13 @@ export class PluginManager {
   }
 
   register(plugin: IPlugin) {
-    assert(
-      plugin.apply && plugin.path,
-      `plugin register failed, apply and path must supplied`,
-    );
+    assert(plugin.apply, `plugin register failed, apply must supplied`);
     Object.keys(plugin.apply).forEach((key) => {
       assert(
         this.opts.validKeys.indexOf(key) > -1,
-        `register failed, invalid key ${key} from plugin ${plugin.path}.`,
+        `register failed, invalid key ${key} ${
+          plugin.path ? `from plugin ${plugin.path}` : ''
+        }.`,
       );
       this.hooks[key] = (this.hooks[key] || []).concat(plugin.apply[key]);
     });


### PR DESCRIPTION

1. 防止 `layouts` 的本地文件全路径泄露到产物里，做个 alias 替换掉 prefix 。

2. 防止 client plugins 里的 `file` 字段里本地文件全路径泄露到产物里，由于没有强依赖这个路径，生产环境直接 `undefined` 。
