### PR TITLE
fix(preview): fallback order should after static resources

### DIFF
--- a/packages/preset-umi/src/commands/preview.ts
+++ b/packages/preset-umi/src/commands/preview.ts
@@ -88,15 +88,6 @@ umi preview --port [port]
         }),
       );
 
-      // history fallback
-      app.use(
-        require('@umijs/bundler-webpack/compiled/connect-history-api-fallback')(
-          {
-            index: '/',
-          },
-        ),
-      );
-
       app.use(
         api.config.base,
         sirv(distDir, {
@@ -104,6 +95,11 @@ umi preview --port [port]
           dev: true,
           single: true,
         }),
+      );
+
+      // history fallback
+      app.use(
+        require('@umijs/bundler-webpack/compiled/connect-history-api-fallback')(),
       );
 
       // https 复用用户配置


### PR DESCRIPTION
修复 `umi preview` 访问不到页面的问题，应该先过静态资源中间件再 fallback 。