### PR TITLE
feat(build): support legacy bundle mode for low version browsers

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -332,7 +332,7 @@ scripts: ['https://unpkg.com/react@17.0.1/umd/react.production.min.js'],
 
 ## extraBabelIncludes
 
-* 类型：`string[]`
+* 类型：`(string | RegExp)[]`
 * 默认值：`[]`
 
 配置额外需要做 Babel 编译的 NPM 包或目录。比如：
@@ -344,6 +344,8 @@ export default {
     join(__dirname, '../../common'),
     // 支持 npm 包
     'react-monaco-editor',
+    // 转译全部 node_modules
+    /node_modules/
   ],
 };
 ```

--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -332,7 +332,7 @@ scripts: ['https://unpkg.com/react@17.0.1/umd/react.production.min.js'],
 
 ## extraBabelIncludes
 
-* 类型：`(string | RegExp)[]`
+* 类型：`Array<string | RegExp>`
 * 默认值：`[]`
 
 配置额外需要做 Babel 编译的 NPM 包或目录。比如：
@@ -532,6 +532,29 @@ https: {
 
 */
 }
+
+## legacyBundle
+
+- 类型：`boolean | { transformAllDeps?: boolean }`
+- 默认值：`false`
+
+当你需要兼容低版本浏览器时，可能需要该选项，开启后将默认使用如下 **非现代** 的打包工具做构建，这会显著增加你的构建时间成本：
+
+- 使用 `babel` 来转译 ts / js 源码
+- 使用 `terser` 来压缩 js 产物
+- 使用 `cssnano` 来压缩 css 产物
+
+```ts
+legacyBundle: {}
+```
+
+当你需要转译更多第三方依赖时，可以将其配置至 [`extraBabelIncludes`](#extrababelincludes) ，或使用 `transformAllDeps` 默认转译全部 `node_modules` 的源码，这会需要更长的时间：
+
+```ts
+legacyBundle: {
+  transformAllDeps: true
+}
+```
 
 ## lessLoader
 

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -35,7 +35,7 @@ export interface IOpts {
   entry: Record<string, string>;
   extraBabelPresets?: any[];
   extraBabelPlugins?: any[];
-  extraBabelIncludes?: string[];
+  extraBabelIncludes?: Array<string | RegExp>;
   extraEsbuildLoaderHandler?: any[];
   babelPreset?: any;
   chainWebpack?: Function;

--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -1,6 +1,6 @@
 import type { Program } from '@swc/core';
 import { autoCssModulesHandler, esbuildLoader } from '@umijs/mfsu';
-import { chalk } from '@umijs/utils';
+import { chalk, lodash } from '@umijs/utils';
 import { dirname, isAbsolute } from 'path';
 import { ProvidePlugin } from '../../compiled/webpack';
 import Config from '../../compiled/webpack-5-chain';
@@ -15,7 +15,7 @@ interface IOpts {
   env: Env;
   extraBabelPlugins: any[];
   extraBabelPresets: any[];
-  extraBabelIncludes: string[];
+  extraBabelIncludes: Array<string | RegExp>;
   extraEsbuildLoaderHandler: any[];
   babelPreset: any;
   name?: string;
@@ -48,6 +48,12 @@ export async function addJavaScriptRules(opts: IOpts) {
       .include.add([
         // support extraBabelIncludes
         ...opts.extraBabelIncludes.map((p) => {
+          // regexp
+          if (lodash.isRegExp(p)) {
+            return p;
+          }
+
+          // string
           // handle absolute path
           if (isAbsolute(p)) {
             return p;

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -76,7 +76,10 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     esm: (Joi) => Joi.object(),
     externals: (Joi) =>
       Joi.alternatives().try(Joi.object(), Joi.string(), Joi.func()),
-    extraBabelIncludes: (Joi) => Joi.array().items(Joi.string()),
+    extraBabelIncludes: (Joi) =>
+      Joi.array().items(
+        Joi.alternatives().try(Joi.string(), Joi.object().instance(RegExp)),
+      ),
     extraBabelPlugins: (Joi) =>
       Joi.array().items(Joi.alternatives().try(Joi.string(), Joi.array())),
     extraBabelPresets: (Joi) =>

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -67,7 +67,7 @@ export interface IConfig {
   esm?: { [key: string]: any };
   extraBabelPlugins?: IBabelPlugin[];
   extraBabelPresets?: IBabelPlugin[];
-  extraBabelIncludes?: string[];
+  extraBabelIncludes?: Array<string | RegExp>;
   extraPostCSSPlugins?: any[];
   hash?: boolean;
   ignoreMomentLocale?: boolean;

--- a/packages/create-umi/src/cli.ts
+++ b/packages/create-umi/src/cli.ts
@@ -1,6 +1,4 @@
-import { chalk, yParser } from '@umijs/utils';
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { chalk, isUmiLocal, yParser } from '@umijs/utils';
 
 const args = yParser(process.argv.slice(2), {
   alias: {
@@ -12,9 +10,7 @@ const args = yParser(process.argv.slice(2), {
 
 if (args.version && !args._[0]) {
   args._[0] = 'version';
-  const local = existsSync(join(__dirname, '../.local'))
-    ? chalk.cyan('@local')
-    : '';
+  const local = isUmiLocal() ? chalk.cyan('@local') : '';
   const { name, version } = require('../package.json');
   console.log(`${name}@${version}${local}`);
 } else {

--- a/packages/preset-umi/src/features/compatible/degradeBundle.ts
+++ b/packages/preset-umi/src/features/compatible/degradeBundle.ts
@@ -1,0 +1,125 @@
+import {
+  CSSMinifier,
+  Env,
+  JSMinifier,
+  Transpiler,
+} from '@umijs/bundler-webpack/dist/types';
+import { chalk, lodash } from '@umijs/utils';
+import assert from 'assert';
+import type { IApi } from '../../types';
+
+interface IDegradeBundleOpts {
+  transformAllDeps?: boolean;
+}
+
+export default (api: IApi) => {
+  api.describe({
+    key: 'degradeBundle',
+    config: {
+      schema(Joi) {
+        return Joi.alternatives(
+          Joi.boolean(),
+          Joi.object({
+            transformAllDeps: Joi.boolean(),
+          }),
+        );
+      },
+    },
+    enableBy: ({ env, userConfig }) => {
+      return userConfig.degradeBundle && env === Env.production;
+    },
+  });
+
+  api.modifyConfig({
+    stage: Number.MAX_SAFE_INTEGER,
+    fn: (memo) => {
+      const { userConfig } = api;
+      const { degradeBundle } = userConfig;
+      const opts: IDegradeBundleOpts = lodash.isBoolean(degradeBundle)
+        ? {}
+        : degradeBundle;
+
+      assert(
+        !userConfig.srcTranspiler &&
+          !userConfig.jsMinifier &&
+          !userConfig.cssMinifier,
+        `Manual configuration ${['srcTranspiler', 'jsMinifier', 'cssMinifier']
+          .map((i) => chalk.yellow(i))
+          .join(', ')} is not supported in ${chalk.cyan('degradeBundle')} mode`,
+      );
+
+      /**
+       * 🟢 babel:    only babel supported transform to es5
+       * 🟡 swc:      support es5, but existence of edge case
+       * 🔴 esbuild:  not supported es5
+       */
+      memo.srcTranspiler = Transpiler.babel;
+
+      /**
+       * 🟢 terser:   keep ecma target, same behavior as old bundle cli
+       * 🟡 uglifyJs: cannot compress some package, may throw error
+       * 🟡 swc:      support es5, but existence of edge case, need additional install @swc/core dep
+       * 🔴 esbuild:  not supported es5
+       */
+      memo.jsMinifier = JSMinifier.terser;
+
+      /**
+       * 🟢 cssnano:   same behavior as before
+       * 🟢 parcelCSS: support low version targets, but need additional install package
+       * 🔴 esbuild:   not supported low version browser as targets
+       */
+      memo.cssMinifier = CSSMinifier.cssnano;
+
+      // specified a old browser target
+      memo.targets = {
+        ...userConfig.targets,
+        ie: 10,
+      };
+
+      // extend the range of babel transform as much as possible
+      // so the source code will all transform to es5
+      if (opts?.transformAllDeps) {
+        const cwd = process.cwd();
+        memo.extraBabelIncludes = [
+          ...(Array.isArray(memo.extraBabelIncludes)
+            ? memo.extraBabelIncludes
+            : []),
+          /node_modules/,
+          cwd,
+        ].filter(Boolean);
+      }
+
+      return memo;
+    },
+  });
+
+  api.chainWebpack((memo) => {
+    if (!api.userConfig.svgr) return;
+
+    // transform svgr outputs to es5
+    memo.module
+      .rule('svgr')
+      .use('babel-loader')
+      .loader(require.resolve('@umijs/bundler-webpack/compiled/babel-loader'))
+      .options({
+        sourceType: 'unambiguous',
+        babelrc: false,
+        cacheDirectory: false,
+        targets: api.config.targets,
+        presets: [
+          [
+            require.resolve('@umijs/babel-preset-umi'),
+            {
+              presetEnv: {},
+              presetReact: {},
+              presetTypeScript: {},
+            },
+          ],
+        ],
+      })
+      .before('svgr-loader')
+      .end();
+
+    return memo;
+  });
+};

--- a/packages/preset-umi/src/features/compatible/legacyBundle.ts
+++ b/packages/preset-umi/src/features/compatible/legacyBundle.ts
@@ -8,13 +8,13 @@ import { chalk, lodash } from '@umijs/utils';
 import assert from 'assert';
 import type { IApi } from '../../types';
 
-interface IDegradeBundleOpts {
+interface ILegacyBundleOpts {
   transformAllDeps?: boolean;
 }
 
 export default (api: IApi) => {
   api.describe({
-    key: 'degradeBundle',
+    key: 'legacyBundle',
     config: {
       schema(Joi) {
         return Joi.alternatives(
@@ -26,7 +26,7 @@ export default (api: IApi) => {
       },
     },
     enableBy: ({ env, userConfig }) => {
-      return userConfig.degradeBundle && env === Env.production;
+      return userConfig.legacyBundle && env === Env.production;
     },
   });
 
@@ -34,10 +34,10 @@ export default (api: IApi) => {
     stage: Number.MAX_SAFE_INTEGER,
     fn: (memo) => {
       const { userConfig } = api;
-      const { degradeBundle } = userConfig;
-      const opts: IDegradeBundleOpts = lodash.isBoolean(degradeBundle)
+      const { legacyBundle } = userConfig;
+      const opts: ILegacyBundleOpts = lodash.isBoolean(legacyBundle)
         ? {}
-        : degradeBundle;
+        : legacyBundle;
 
       assert(
         !userConfig.srcTranspiler &&
@@ -45,7 +45,7 @@ export default (api: IApi) => {
           !userConfig.cssMinifier,
         `Manual configuration ${['srcTranspiler', 'jsMinifier', 'cssMinifier']
           .map((i) => chalk.yellow(i))
-          .join(', ')} is not supported in ${chalk.cyan('degradeBundle')} mode`,
+          .join(', ')} is not supported in ${chalk.cyan('legacyBundle')} mode`,
       );
 
       /**

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -1,5 +1,4 @@
 import { getSchemas as getViteSchemas } from '@umijs/bundler-vite/dist/schema';
-import { DEFAULT_BROWSER_TARGETS } from '@umijs/bundler-webpack/dist/constants';
 import { getSchemas as getWebpackSchemas } from '@umijs/bundler-webpack/dist/schema';
 import { resolve } from '@umijs/utils';
 import { dirname, join } from 'path';
@@ -54,7 +53,6 @@ export default (api: IApi) => {
     mountElementId: 'root',
     base: '/',
     history: { type: 'browser' },
-    targets: DEFAULT_BROWSER_TARGETS,
   };
 
   const bundleSchemas = api.config.vite

--- a/packages/preset-umi/src/features/monorepo/redirect.ts
+++ b/packages/preset-umi/src/features/monorepo/redirect.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
-import { getPackages } from '../../../compiled/@manypkg/get-packages';
-import { logger } from '@umijs/utils';
+import { isUmiLocal, logger } from '@umijs/utils';
 import { pkgUp } from '@umijs/utils/compiled/pkg-up';
 import assert from 'assert';
 import { existsSync, statSync } from 'fs';
 import { dirname, join } from 'path';
+import { getPackages } from '../../../compiled/@manypkg/get-packages';
 import type { IApi } from '../../types';
 
 interface IConfigs {
@@ -41,7 +41,7 @@ export default (api: IApi) => {
     const config: IConfigs = memo.monorepoRedirect || {};
     const { exclude = [], srcDir = ['src'] } = config;
     // Note: not match `umi` package in local dev
-    if (__filename.includes(`packages/preset-umi`)) {
+    if (isUmiLocal()) {
       logger.info(
         `[monorepoRedirect]: Auto excluded 'umi' package in local dev scene`,
       );

--- a/packages/preset-umi/src/features/monorepo/redirect.ts
+++ b/packages/preset-umi/src/features/monorepo/redirect.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
 import { isUmiLocal, logger } from '@umijs/utils';
 import { pkgUp } from '@umijs/utils/compiled/pkg-up';
 import assert from 'assert';
 import { existsSync, statSync } from 'fs';
 import { dirname, join } from 'path';
+// @ts-ignore
 import { getPackages } from '../../../compiled/@manypkg/get-packages';
 import type { IApi } from '../../types';
 

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -28,6 +28,7 @@ export default () => {
       require.resolve('./features/vite/vite'),
       require.resolve('./features/apiRoute/apiRoute'),
       require.resolve('./features/monorepo/redirect'),
+      require.resolve('./features/compatible/degradeBundle'),
 
       // commands
       require.resolve('./commands/build'),

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -28,7 +28,7 @@ export default () => {
       require.resolve('./features/vite/vite'),
       require.resolve('./features/apiRoute/apiRoute'),
       require.resolve('./features/monorepo/redirect'),
-      require.resolve('./features/compatible/degradeBundle'),
+      require.resolve('./features/compatible/legacyBundle'),
 
       // commands
       require.resolve('./commands/build'),

--- a/packages/renderer-react/tsconfig.json
+++ b/packages/renderer-react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es5",
     "module": "esnext",
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/renderer-vue/tsconfig.json
+++ b/packages/renderer-vue/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es5",
     "module": "esnext",
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/umi/src/cli/node.ts
+++ b/packages/umi/src/cli/node.ts
@@ -1,4 +1,4 @@
-import { logger } from '@umijs/utils';
+import { isUmiLocal, logger } from '@umijs/utils';
 import { FRAMEWORK_NAME, MIN_NODE_VERSION } from '../constants';
 
 export function checkVersion() {
@@ -12,7 +12,7 @@ export function checkVersion() {
 }
 
 export function checkLocal() {
-  if (__filename.includes(`packages/${FRAMEWORK_NAME}`)) {
+  if (isUmiLocal()) {
     logger.info('@local');
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,6 +29,7 @@ import updatePackageJSON from './updatePackageJSON';
 export * from './getCorejsVersion';
 export * from './importLazy';
 export * from './isStyleFile';
+export * from './isUmiLocal';
 export * from './npmClient';
 export * from './randomColor/randomColor';
 export * as register from './register';

--- a/packages/utils/src/isUmiLocal.ts
+++ b/packages/utils/src/isUmiLocal.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const root = join(__dirname, '../../../');
+const lernaPath = join(root, './lerna.json');
+const rootPkgPath = join(root, './package.json');
+const currentPkg = require(join(__dirname, '../package.json'));
+
+/**
+ * check weather in local dev umi
+ */
+export const isUmiLocal = () => {
+  return (
+    existsSync(lernaPath) &&
+    existsSync(rootPkgPath) &&
+    require(lernaPath).version === currentPkg.version
+  );
+};


### PR DESCRIPTION

尝试解 @xiaohuoni 的问题。

1. 支持 `legacyBundle: {}` 插件一键回到 legacy 的非现代化打包工具环境，排除现代打包工具后，用户剩下要做的就是排查要额外 `include` 的包，配到 `extraBabelIncludes` 里，这里额外再支持懒人做法一键 all in 全部依赖都 transform。

2. 给 `extraBabelIncludes` 支持正则，使用起来更灵活。

3. 编码过程中发现、顺手抽取了 判断本地开发 方法的冗余代码。

4. 文档补全。

5. 传导 `targets` 的时候发现 `targets` 的默认值不需要给，后面 `getConfigs` 有兜底，否则就被 merge 不符合预期了。

7. `renderer-*` 系列的包要直接被引用跑到浏览器里，和 `client/client` 一致都做成 `es5` 的格式，增加兼容性。


目前的实现结果：

1. 不使用 `externals` 的 `examples/boilerplate` 项目经过：

   ```bash
     es-check es5 './dist/*.js'
   ``` 

    检验通过。


2. 有 `externals` 的情况 webpack 会给注入 `async function` ，没法转译，现在完美兼容 es5 真的太困难。

 
