### PR TITLE
feat(renderer-vue): vue router support extra params

### DIFF
--- a/packages/renderer-vue/src/routes.ts
+++ b/packages/renderer-vue/src/routes.ts
@@ -38,10 +38,11 @@ export function createClientRoute(opts: {
   parentId?: string;
 }) {
   const { route } = opts;
-  const { id, path, redirect } = route;
+  const { id, path, redirect, ...other } = route;
 
   if (redirect) {
     return {
+      ...other,
       id,
       path,
       redirect,
@@ -49,6 +50,7 @@ export function createClientRoute(opts: {
   }
 
   const item: Record<string, any> = {
+    ...other,
     id,
     component: opts.routeComponent,
     path,


### PR DESCRIPTION
之前实现时缺省了 其它参数, 补齐下

主要用于路由配置meta 之类的需要, 可以通过 `useRoute` 获取 或者一些别的操作 更多详见 https://router.vuejs.org/guide/advanced/meta.html

```tsx
routes: [
    {
      path: '/',
      component: 'index',
      meta: {
        hello: 2
      },
      props: {
        xx: 2
      }
    }
  ]
```