### PR TITLE
test: ✅ jest config ignore compiled code

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,7 @@ import { Config, createConfig } from 'umi/test';
 
 export default {
   ...createConfig(),
-  testMatch: ['**/packages/*/src/**/*.test.ts'],
+  testMatch: ['<rootDir>/packages/*/src/**/*.test.ts'],
   modulePathIgnorePatterns: [
     '<rootDir>/packages/.+/compiled',
     '<rootDir>/packages/.+/fixtures',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,5 @@ export default {
     '<rootDir>/packages/.+/compiled',
     '<rootDir>/packages/.+/fixtures',
   ],
-
   transformIgnorePatterns: ['/node_modules/', '/compiled/'],
 } as Config.InitialOptions;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,12 +8,5 @@ export default {
     '<rootDir>/packages/.+/fixtures',
   ],
 
-  transformIgnorePatterns: [
-    // default values
-    '/node_modules/',
-    '\\.pnp\\.[^\\/]+$',
-
-    // for umi-next self
-    '/compiled/',
-  ],
+  transformIgnorePatterns: ['/node_modules/', '/compiled/'],
 } as Config.InitialOptions;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,4 +7,13 @@ export default {
     '<rootDir>/packages/.+/compiled',
     '<rootDir>/packages/.+/fixtures',
   ],
+
+  transformIgnorePatterns: [
+    // default values
+    '/node_modules/',
+    '\\.pnp\\.[^\\/]+$',
+
+    // for umi-next self
+    '/compiled/',
+  ],
 } as Config.InitialOptions;


### PR DESCRIPTION
配置 jest transform 忽略  compiled code，不然本地执行 单测巨卡 巨慢

下面 400s 都没开始执行用例
```bash
$time npm t

> test
> jest


 RUNS  packages/bundler-webpack/src/build.test.ts
 RUNS  packages/bundler-vite/src/build.test.ts
 RUNS  packages/bundler-esbuild/src/build.test.ts
 RUNS  packages/plugin-docs/src/compiler.test.ts
 RUNS  packages/babel-preset-umi/src/index.test.ts
 RUNS  packages/mfsu/src/babelPlugins/awaitImport/awaitImport.test.ts
 RUNS  packages/preset-umi/src/commands/generators/page.test.ts

Test Suites: 0 of 61 total
Tests:       0 total
Snapshots:   0 total
Time:        400 s
```