### PR TITLE
fix(targets): not set default targets value

### DIFF
--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -1,5 +1,4 @@
 import { getSchemas as getViteSchemas } from '@umijs/bundler-vite/dist/schema';
-import { DEFAULT_BROWSER_TARGETS } from '@umijs/bundler-webpack/dist/constants';
 import { getSchemas as getWebpackSchemas } from '@umijs/bundler-webpack/dist/schema';
 import { resolve } from '@umijs/utils';
 import { dirname, join } from 'path';
@@ -54,7 +53,6 @@ export default (api: IApi) => {
     mountElementId: 'root',
     base: '/',
     history: { type: 'browser' },
-    targets: DEFAULT_BROWSER_TARGETS,
     svgr: {},
   };
 


### PR DESCRIPTION
`targets` 不需要给 default 值，否则会被合并，不符合预期。

因为 `targets` 在 getConfig 的时候会判断是不是空值给予默认值了。