### PR TITLE
fix(prettier): prettier cannot find plugin dir in pnpm `node_modules` (resolve #820)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "printWidth": 80,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "proseWrap": "never",
-  "overrides": [{ "files": ".prettierrc", "options": { "parser": "json" } }],
-  "plugins": ["prettier-plugin-packagejson", "./scripts/prettier-plugin"]
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  printWidth: 80,
+  singleQuote: true,
+  trailingComma: 'all',
+  proseWrap: 'never',
+  plugins: [
+    require.resolve('prettier-plugin-packagejson'),
+    './scripts/prettier-plugin',
+  ],
+};


### PR DESCRIPTION
修理 pnpm 的 `node_modules` 层次结构下，prettier 插件无法正确查找到 `plugins` 的位置。

See #820 