### PR TITLE
fix(bundler-webpack): Fix runtimePublicPath effects assets url in css file

### DIFF
--- a/packages/bundler-webpack/src/build.test.ts
+++ b/packages/bundler-webpack/src/build.test.ts
@@ -99,6 +99,9 @@ const expects: Record<string, Function> = {
   'postcss-flexbugs-fixes'({ files }: IOpts) {
     expect(files['index.css']).toContain(`.foo { flex: 1 1; }`);
   },
+  'runtime-public-path'({ files }: IOpts) {
+    expect(files['index.css']).toContain(`background: url(./static/`);
+  },
   svgo({ files }: IOpts) {
     expect(files['static']).toContain(EXISTS);
     expect(files['index.js']).toContain(`.svg`);

--- a/packages/bundler-webpack/src/fixtures/runtime-public-path/config.ts
+++ b/packages/bundler-webpack/src/fixtures/runtime-public-path/config.ts
@@ -1,0 +1,3 @@
+export default {
+  runtimePublicPath: {}
+};

--- a/packages/bundler-webpack/src/fixtures/runtime-public-path/index.css
+++ b/packages/bundler-webpack/src/fixtures/runtime-public-path/index.css
@@ -1,0 +1,3 @@
+body {
+  background: url("./bg.jpg");
+}

--- a/packages/bundler-webpack/src/fixtures/runtime-public-path/index.ts
+++ b/packages/bundler-webpack/src/fixtures/runtime-public-path/index.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -11,8 +11,12 @@ export class RuntimePublicPathPlugin {
         // https://github.com/webpack/webpack/blob/master/lib/runtime/PublicPathRuntimeModule.js
         if (module.constructor.name === 'PublicPathRuntimeModule') {
           // If current public path is handled by mini-css-extract-plugin, skip it
-          if (module.getGeneratedCode().startsWith(
-            'webpack:///mini-css-extract-plugin')) return;
+          if (
+            module
+              .getGeneratedCode()
+              .includes('webpack:///mini-css-extract-plugin')
+          )
+            return;
           // @ts-ignore
           module._cachedGeneratedCode = `__webpack_require__.p = (globalThis || window).publicPath || '/';`;
         }

--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -11,11 +11,7 @@ export class RuntimePublicPathPlugin {
         // https://github.com/webpack/webpack/blob/master/lib/runtime/PublicPathRuntimeModule.js
         if (module.constructor.name === 'PublicPathRuntimeModule') {
           // If current public path is handled by mini-css-extract-plugin, skip it
-          if (
-            module
-              .getGeneratedCode()
-              .includes('webpack:///mini-css-extract-plugin')
-          )
+          if (module.getGeneratedCode().includes('webpack:///mini-css-extract-plugin'))
             return;
           // @ts-ignore
           module._cachedGeneratedCode = `__webpack_require__.p = (globalThis || window).publicPath || '/';`;

--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -10,6 +10,9 @@ export class RuntimePublicPathPlugin {
         // The hook to get the public path ('__webpack_require__.p')
         // https://github.com/webpack/webpack/blob/master/lib/runtime/PublicPathRuntimeModule.js
         if (module.constructor.name === 'PublicPathRuntimeModule') {
+          // If current public path is handled by mini-css-extract-plugin, skip it
+          if (module.getGeneratedCode().startsWith(
+            'webpack:///mini-css-extract-plugin')) return;
           // @ts-ignore
           module._cachedGeneratedCode = `__webpack_require__.p = (globalThis || window).publicPath || '/';`;
         }


### PR DESCRIPTION
### 修复问题

开启 `runtimePublicPath` 之后 CSS 中引用 assets 资源的 `publicPath` 不是 `./` 而是 `/`

### 复现步骤

1、`umi g page index`
2、项目中新增一个超过 10K 的图片
3、在 css 中引用他
4、配置 `runtimePublicPath: {}`
5、执行 `COMPRESS=none umi build`

检查 `dist` 下的 `css` 文件，针对图片的引用，期望是通过 `./static/xxx` 的方式引入，而实际上是通过 `/static/xxx` 的方式引入。

### 解决方案

原本 css 针对图片的引用是由 mini-css-extract 插件负责处理，但因为 runtimePublicPath 插件直接无条件将所有模块的 publicPath 都覆盖掉，导致问题发生。

在覆盖 publicPath 以前先判断该模块是否由 mini-css-extract 插件负责，如果是的话则不该动他的 publicPath 即可修复问题。