### PR TITLE
refactor: 🎨 better types for access component

### DIFF
--- a/packages/plugins/src/access.ts
+++ b/packages/plugins/src/access.ts
@@ -60,7 +60,7 @@ export function accessProvider(container) {
     api.writeTmpFile({
       path: 'index.tsx',
       content: `
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { AccessContext } from './context';
 import type { IRoute } from 'umi';
 
@@ -72,7 +72,7 @@ export interface AccessProps {
   accessible: boolean;
   fallback?: React.ReactNode;
 }
-export const Access: React.FC<AccessProps> = (props) => {
+export const Access: React.FC<PropsWithChildren<AccessProps>> = (props) => {
   if (process.env.NODE_ENV === 'development' && typeof props.accessible !== 'boolean') {
     throw new Error('[access] the \`accessible\` property on <Access /> should be a boolean');
   }


### PR DESCRIPTION
Access 组件类型报错

```text
Type '{ children: Element; accessible: any; }' is not assignable to type 'IntrinsicAttributes & AccessProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & AccessProps'.

(alias) const Access: React.FC<AccessProps>
import Access
```
原因  react18 类型定义移除了 `PropsWithChildren`，导致以上类型报错;  PR 中的改动在 React17 的环境下 会变成
`PropsWithChildren<PropsWithChildren<P>>` 等效于 `PropsWithChildren<P>`，可以兼容
```diff
 interface FunctionComponent<P = {}> {
-       (props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
+       (props: P, context?: any): ReactElement<any, any> | null;
```