### PR TITLE
feat(umi): 新增 defineMock 方法

### DIFF
--- a/docs/docs/guides/mock.md
+++ b/docs/docs/guides/mock.md
@@ -100,6 +100,24 @@ export default {
 
 关于 `req` 和 `res` 的 API 可参考 [Express@4 官方文档](https://expressjs.com/en/api.html) 来进一步了解。
 
+### defineMock
+
+另外，也可以使用 defineMock 函数声明返回值，例如：
+```ts
+import { defineMock } from "umi";
+
+export default defineMock({
+  "/api/users": [
+    { id: 1, name: "foo" },
+    { id: 2, name: "bar" },
+  ],
+  "/api/users/1": { id: 1, name: "foo" },
+  "GET /api/users/2": (req, res) => {
+    res.status(200).json({ id: 2, name: "bar" });
+  },
+});
+```
+defineMock 仅仅是提供了类型提示，入参与出参是完全一样的，类似与 lodash 的 identity 函数
 ## 关闭 Mock
 
 Umi 默认开启 Mock 功能，如果不需要的话可以从配置文件关闭：

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -446,6 +446,10 @@ export default function EmptyRoute() {
           path: '@@/core/terminal.ts',
         });
       }
+      // umi/dist/defineMock.js
+      exports.push('// defineMock');
+      const umiPath = winPath(join(umiDir, 'dist/defineMock.js'));
+      exports.push(`export { defineMock } from '${umiPath}'`);
       // plugins
       exports.push('// plugins');
       const plugins = readdirSync(api.paths.absTmpPath).filter((file) => {

--- a/packages/umi/src/defineMock.ts
+++ b/packages/umi/src/defineMock.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from '@umijs/bundler-webpack/compiled/express';
+
+type IValue =
+  | string
+  | number
+  | null
+  | undefined
+  | boolean
+  | Record<string, any>
+  | RequestHandler;
+
+export function defineMock(mockData: { [key: string]: IValue }) {
+  return mockData;
+}

--- a/packages/umi/src/index.ts
+++ b/packages/umi/src/index.ts
@@ -2,5 +2,6 @@ import { IServicePluginAPI, PluginAPI } from '@umijs/core';
 
 export { run } from './cli/cli';
 export { defineConfig } from './defineConfig';
+export { defineMock } from './defineMock';
 export * from './service/service';
 export type IApi = PluginAPI & IServicePluginAPI;


### PR DESCRIPTION
新增 defineMock 方法，给 mock 加上类型提示。

```ts
import { defineMock } from "umi";

export default defineMock({
  "/api/users": [
    { id: 1, name: "foo" },
    { id: 2, name: "bar" },
  ],
  "/api/users/1": { id: 1, name: "foo" },
  "GET /api/users/2": (req, res) => {
    res.status(200).json({ id: 2, name: "bar" });
  },
});
```