### PR TITLE
feat(plugin-docs): Add color-scheme support

### DIFF
--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -35,9 +35,17 @@ export default () => {
     if (toggle) {
       document.body.classList.remove('dark');
       localStorage.setItem('theme', 'light');
+      window.document.documentElement.style.setProperty(
+        '--color-scheme',
+        'light',
+      );
     } else {
       document.body.classList.add('dark');
       localStorage.setItem('theme', 'dark');
+      window.document.documentElement.style.setProperty(
+        '--color-scheme',
+        'dark',
+      );
     }
   }, [toggle]);
 

--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -208,6 +208,8 @@ html {
 
 :root {
   --anchor-offset: 28px;
+
+  color-scheme: var(--color-scheme, light dark);
 }
 
 /** Anchor with offset for headings */


### PR DESCRIPTION
使用 color-scheme CSS 属性改进深色模式默认样式。

## 改进前：
![before](https://user-images.githubusercontent.com/47730755/172613626-6864bc5e-06f6-459c-8f44-90496f657359.jpg)

## 改进后：
![after](https://user-images.githubusercontent.com/47730755/172613655-dadf3d72-ae16-492f-b5b8-851166c0135d.jpg)

