### PR TITLE
fix(plugins): runtime routes patch bug for qiankun

### DIFF
--- a/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
+++ b/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
@@ -34,7 +34,7 @@ function patchMicroAppRouteComponent(routes: any[]) {
     const rootRoute = routes.find((route) => route.path === '/');
     if (rootRoute) {
       // 如果根路由是叶子节点，则直接返回其父节点
-      if (!rootRoute.children) {
+      if (!rootRoute.children?.length) {
         return routes;
       }
       return getRootRoutes(rootRoute.children);


### PR DESCRIPTION
## Description

修复运行时路由 patch 位置出错的 bug，#821 默认加了空的 `children`，已确定会改回去，但安全起见这里还是再判断下 `length`