### PR TITLE
fix(renderer-react): 修复createClientRoute返回值children和routes默认值为空数组后，导致…

### DIFF
--- a/packages/renderer-react/src/routes.tsx
+++ b/packages/renderer-react/src/routes.tsx
@@ -44,8 +44,6 @@ function createClientRoute(opts: {
   const { route } = opts;
   const { redirect, ...props } = route;
   return {
-    children: [],
-    routes: [],
     element: redirect ? (
       <Navigate to={redirect} />
     ) : (

--- a/packages/renderer-react/src/types.ts
+++ b/packages/renderer-react/src/types.ts
@@ -10,9 +10,9 @@ export interface IRoute {
 export interface IClientRoute {
   id: string;
   element: React.ReactNode;
-  children: IClientRoute[];
+  children?: IClientRoute[];
   // compatible with @ant-design/pro-layout
-  routes: IClientRoute[];
+  routes?: IClientRoute[];
   path?: string;
   index?: boolean;
   parentId?: string;


### PR DESCRIPTION
修复因为createClientRoute返回值children和routes默认值为空数组后， route.children 的判断一直为真值，而引起一些问题。