### PR TITLE
fix(preset-umi): 取消typescript关于import json的错误的类型提示

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -51,6 +51,8 @@ export default (api: IApi) => {
             sourceMap: true,
             baseUrl,
             strict: true,
+            resolveJsonModule: true,
+            allowSyntheticDefaultImports: true,
             paths: {
               '@/*': [`${srcPrefix}*`],
               '@@/*': [`${srcPrefix}.umi/*`],
@@ -64,8 +66,6 @@ export default (api: IApi) => {
                   }
                 : {}),
             },
-            allowSyntheticDefaultImports: true,
-            resolveJsonModule: true,
           },
         },
         null,

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -65,6 +65,7 @@ export default (api: IApi) => {
                 : {}),
             },
             allowSyntheticDefaultImports: true,
+            resolveJsonModule: true,
           },
         },
         null,


### PR DESCRIPTION
目前，umi 支持导入 json 文件，但是 tsconfig.json 中不存在 resolveJsonModule: true 配置，typescript 就认为找不到模块。编辑器会在导入 json 文件的地方，出现红色下划线，这会给用户造成困扰。
如图：
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/15035094/172976466-5a90def5-a44e-4e1a-ace9-40593ee7932e.png">
