### PR TITLE
chore: extract check local method

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,6 @@
         "redux"
       ]
     }
-  }
+  },
+  "_local": "This flag is used to check if the development in local, Please do not delete."
 }

--- a/packages/create-umi/src/cli.ts
+++ b/packages/create-umi/src/cli.ts
@@ -1,6 +1,4 @@
-import { chalk, yParser } from '@umijs/utils';
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { chalk, isLocalDev, yParser } from '@umijs/utils';
 
 const args = yParser(process.argv.slice(2), {
   alias: {
@@ -12,9 +10,7 @@ const args = yParser(process.argv.slice(2), {
 
 if (args.version && !args._[0]) {
   args._[0] = 'version';
-  const local = existsSync(join(__dirname, '../.local'))
-    ? chalk.cyan('@local')
-    : '';
+  const local = isLocalDev() ? chalk.cyan('@local') : '';
   const { name, version } = require('../package.json');
   console.log(`${name}@${version}${local}`);
 } else {

--- a/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
@@ -1,17 +1,19 @@
 import * as Babel from '@umijs/bundler-utils/compiled/babel/core';
-import { winPath } from '@umijs/utils';
+import { isLocalDev, winPath } from '@umijs/utils';
 import assert from 'assert';
-import { isAbsolute } from 'path';
+import { isAbsolute, join } from 'path';
 import type { IOpts } from './awaitImport';
 import { getAliasedPath } from './getAliasedPath';
 import { isExternals } from './isExternals';
 
 // const UNMATCH_LIBS = ['umi', 'dumi', '@alipay/bigfish'];
 const RE_NODE_MODULES = /node_modules/;
-const RE_UMI_LOCAL_DEV = /umi(-next)?\/packages\//;
 
 function isUmiLocalDev(path: string) {
-  return RE_UMI_LOCAL_DEV.test(winPath(path));
+  const rootPath = isLocalDev();
+  return rootPath
+    ? winPath(path).startsWith(join(rootPath, './packages'))
+    : false;
 }
 
 export function checkMatch({

--- a/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
@@ -12,7 +12,7 @@ const RE_NODE_MODULES = /node_modules/;
 function isUmiLocalDev(path: string) {
   const rootPath = isLocalDev();
   return rootPath
-    ? winPath(path).startsWith(join(rootPath, './packages'))
+    ? winPath(path).startsWith(winPath(join(rootPath, './packages')))
     : false;
 }
 

--- a/packages/preset-umi/src/features/monorepo/redirect.ts
+++ b/packages/preset-umi/src/features/monorepo/redirect.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
-import { getPackages } from '../../../compiled/@manypkg/get-packages';
-import { logger } from '@umijs/utils';
+import { isLocalDev, logger } from '@umijs/utils';
 import { pkgUp } from '@umijs/utils/compiled/pkg-up';
 import assert from 'assert';
 import { existsSync, statSync } from 'fs';
 import { dirname, join } from 'path';
+import { getPackages } from '../../../compiled/@manypkg/get-packages';
 import type { IApi } from '../../types';
 
 interface IConfigs {
@@ -41,7 +41,7 @@ export default (api: IApi) => {
     const config: IConfigs = memo.monorepoRedirect || {};
     const { exclude = [], srcDir = ['src'] } = config;
     // Note: not match `umi` package in local dev
-    if (__filename.includes(`packages/preset-umi`)) {
+    if (isLocalDev()) {
       logger.info(
         `[monorepoRedirect]: Auto excluded 'umi' package in local dev scene`,
       );

--- a/packages/preset-umi/src/features/monorepo/redirect.ts
+++ b/packages/preset-umi/src/features/monorepo/redirect.ts
@@ -1,9 +1,9 @@
-// @ts-ignore
 import { isLocalDev, logger } from '@umijs/utils';
 import { pkgUp } from '@umijs/utils/compiled/pkg-up';
 import assert from 'assert';
 import { existsSync, statSync } from 'fs';
 import { dirname, join } from 'path';
+// @ts-ignore
 import { getPackages } from '../../../compiled/@manypkg/get-packages';
 import type { IApi } from '../../types';
 

--- a/packages/umi/src/cli/node.ts
+++ b/packages/umi/src/cli/node.ts
@@ -1,4 +1,4 @@
-import { logger } from '@umijs/utils';
+import { isLocalDev, logger } from '@umijs/utils';
 import { FRAMEWORK_NAME, MIN_NODE_VERSION } from '../constants';
 
 export function checkVersion() {
@@ -12,7 +12,7 @@ export function checkVersion() {
 }
 
 export function checkLocal() {
-  if (__filename.includes(`packages/${FRAMEWORK_NAME}`)) {
+  if (isLocalDev()) {
     logger.info('@local');
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -28,6 +28,7 @@ import * as logger from './logger';
 import updatePackageJSON from './updatePackageJSON';
 export * from './getCorejsVersion';
 export * from './importLazy';
+export * from './isLocalDev';
 export * from './isStyleFile';
 export * from './npmClient';
 export * from './randomColor/randomColor';

--- a/packages/utils/src/isLocalDev.ts
+++ b/packages/utils/src/isLocalDev.ts
@@ -1,0 +1,13 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const root = join(__dirname, '../../../');
+const rootPkg = join(root, './package.json');
+
+/**
+ * Check whether it is development in local
+ */
+export const isLocalDev = () => {
+  const isLocal = existsSync(rootPkg) && require(rootPkg)._local;
+  return isLocal ? root : false;
+};


### PR DESCRIPTION
1. 新增判断是否在本地开发方法 `isLocalDev`

2. 抽离所有判断是否在本地的逻辑

3. 现在 mfsu 本地开发时不限制仓库名了