### PR TITLE
fix: 🐛 无 hash 配置下 使用 async 避免 chunkName 冲突

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -109,7 +109,9 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   config.output
     .path(absOutputPath)
     .filename(useHash ? `[name].[contenthash:8].js` : `[name].js`)
-    .chunkFilename(useHash ? `[name].[contenthash:8].async.js` : `[name].js`)
+    .chunkFilename(
+      useHash ? `[name].[contenthash:8].async.js` : `[name].async.js`,
+    )
     .publicPath(userConfig.publicPath || 'auto')
     .pathinfo(isDev || disableCompress);
 


### PR DESCRIPTION
表现
```bash
info  - Umi v4.0.0-canary.20220609.1
info  - Memory Usage: 1469.73 MB (RSS: 1633.73 MB)
fatal - Error: Conflict: Multiple chunks emit assets to the same filename 13.js (chunks 201 and 13)
    at /Users/git/problem/bigtest/node_modules/_@umijs_bundler-webpack@4.0.0-canary.20220609.1@@umijs/bundler-webpack/compiled/webpack/index.js:60625:12
    at /Users/git/problem/bigtest/node_modules/_@umijs_bundler-webpack@4.0.0-canary.20220609.1@@umijs/bundler-webpack/compiled/webpack/index.js:51251:5
```
路由组件的 chunkname 为  `数字.js` ，编译生成的chunk 的 使用 `[name].js` 和 路由组件冲突了。
