### PR TITLE
fix(tsconfig): typings file alias (resolve #867)

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -31,6 +31,7 @@ export default (api: IApi) => {
 
     // tsconfig.json
     const srcPrefix = api.appData.hasSrcDir ? 'src/' : '';
+    const umiTempDir = `${srcPrefix}.umi`;
     const baseUrl = api.appData.hasSrcDir ? '../../' : '../';
     api.writeTmpFile({
       noPluginDir: true,
@@ -53,10 +54,10 @@ export default (api: IApi) => {
             strict: true,
             paths: {
               '@/*': [`${srcPrefix}*`],
-              '@@/*': [`${srcPrefix}.umi/*`],
+              '@@/*': [`${umiTempDir}/*`],
               [`${api.appData.umi.importSource}`]: [umiDir],
               [`${api.appData.umi.importSource}/typings`]: [
-                `${umiDir}/typings`,
+                `${umiTempDir}/typings`,
               ],
               ...(api.config.vite
                 ? {


### PR DESCRIPTION
fix #867

`typings.d.ts` 位置在 `.umi` 临时文件夹下，而不是在 umi source dir 下 