### PR TITLE
feat(preset-umi): tmpFiles tsconfig add config

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -33,6 +33,7 @@ export default (api: IApi) => {
     const srcPrefix = api.appData.hasSrcDir ? 'src/' : '';
     const umiTempDir = `${srcPrefix}.umi`;
     const baseUrl = api.appData.hasSrcDir ? '../../' : '../';
+
     api.writeTmpFile({
       noPluginDir: true,
       path: 'tsconfig.json',
@@ -54,6 +55,22 @@ export default (api: IApi) => {
             strict: true,
             resolveJsonModule: true,
             allowSyntheticDefaultImports: true,
+
+            // Enforce using `import type` instead of `import` for types
+            importsNotUsedAsValues: 'error',
+
+            // Supported by vue only
+            ...(api.appData.framework === 'vue'
+              ? {
+                  // TODO Actually, it should be vite mode, but here it is written as vue only
+                  // Required in Vite https://vitejs.dev/guide/features.html#typescript
+                  isolatedModules: true,
+                  // For `<script setup>`
+                  // See <https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#preserve-value-imports>
+                  preserveValueImports: true,
+                }
+              : {}),
+
             paths: {
               '@/*': [`${srcPrefix}*`],
               '@@/*': [`${umiTempDir}/*`],

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -48,7 +48,7 @@ export default (api: IApi) => {
             module: 'esnext',
             moduleResolution: 'node',
             importHelpers: true,
-            jsx: 'react-jsx',
+            jsx: api.appData.framework === 'vue' ? 'preserve' : 'react-jsx',
             esModuleInterop: true,
             sourceMap: true,
             baseUrl,


### PR DESCRIPTION
tsconfig 新增了3个配置

- `importsNotUsedAsValues` 
解 webpack5 不支持 `import { IHello } from './types' `形式访问类型声明 需要写成 `import type { IHello} from './types'` 的形式
<img width="826" alt="image" src="https://user-images.githubusercontent.com/7599351/173607301-71340c5b-9a89-4413-810f-770c00243749.png">

**Vue 框架新增两个配置**

- `isolatedModules`
vite 推荐的配置 https://vitejs.dev/guide/features.html#typescript 这里先写成了仅vue 支持

- `preserveValueImports`
 For `<script setup>`
See <https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#preserve-value-imports>

