### PR TITLE
utils/turbo support mult filter

### DIFF
--- a/scripts/.internal/utils.ts
+++ b/scripts/.internal/utils.ts
@@ -76,3 +76,10 @@ export function spawnSync(cmd: string, opts: SpawnSyncOptions) {
   }
   return result;
 }
+
+export function toArray(v: unknown) {
+  if (Array.isArray(v)) {
+    return v;
+  }
+  return [v];
+}

--- a/scripts/turbo.ts
+++ b/scripts/turbo.ts
@@ -1,6 +1,6 @@
 import yArgs from '@umijs/utils/compiled/yargs-parser';
 import { PATHS } from './.internal/constants';
-import { spawnSync } from './.internal/utils';
+import { spawnSync, toArray } from './.internal/utils';
 
 (async () => {
   const args = yArgs(process.argv.slice(2));
@@ -26,11 +26,12 @@ function turbo(opts: {
   const extraCmd = opts.extra ? `-- -- ${opts.extra}` : '';
   const cacheCmd = opts.cache === false ? '--no-cache --force' : '';
   const parallelCmd = opts.parallel ? '--parallel' : '';
+  const filters: string[] = toArray(opts.filter);
 
   const options = [
     opts.cmd,
     `--cache-dir=".turbo"`,
-    `--filter="${opts.filter}"`,
+    filters.map((f) => `--filter="${f}"`).join(' '),
     cacheCmd,
     parallelCmd,
     extraCmd,


### PR DESCRIPTION
编译两个包的时候 ，这样指定的需要

```bash
$ npx umi-scripts  turbo  --cmd build --filter ./examples/max...   --filter ./examples/lint...

umi-scripts: turbo

• Packages in scope: @example/lint, @example/max, @umijs/ast, @umijs/babel-preset-umi, @umijs/bundler-esbuild, @umijs/bundler-utils, @umijs/bundler-vite, @umijs/bundler-webpack, @umijs/core, @umijs/lint, @umijs/max, @umijs/mfsu, @umijs/plugins, @umijs/preset-umi, @umijs/renderer-react, @umijs/server, @umijs/test, @umijs/utils, umi
• Running build in 19 packages

```