### PR TITLE
fix(ssr): start esbuild after middleware file emitted

### DIFF
--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -59,7 +59,7 @@ export { React };
     });
   });
 
-  api.onStart(async () => {
+  api.onSSRStart(async () => {
     await build({
       api,
       watch: api.env === 'development',

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -184,7 +184,7 @@ export async function getRouteComponents(opts: {
     .map((key) => {
       const route = opts.routes[key];
       if (!route.file) {
-        return `'${key}': () => import( './EmptyRoute'),`;
+        return `'${key}': () => import('./EmptyRoute'),`;
       }
       if (route.hasClientLoader) {
         route.file = join(

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -417,6 +417,11 @@ export default function EmptyRoute() {
           env: JSON.stringify(api.env),
         },
       });
+      if (opts.isFirstTime) {
+        api.applyPlugins({
+          key: 'onSSRStart',
+        });
+      }
     }
 
     // history.ts

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -22,6 +22,7 @@ export default (api: IApi) => {
     'onCheckPkgJSON',
     'onCheckCode',
     'onCheckConfig',
+    'onSSRStart',
     'addBeforeMiddlewares',
     'addLayouts',
     'addMiddlewares',

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -171,6 +171,7 @@ export type IApi = PluginAPI &
       current: Record<string, any>;
       origin: Record<string, any>;
     }>;
+    onSSRStart: IEvent<{}>;
     restartServer: () => void;
     writeTmpFile: (opts: {
       content?: string;


### PR DESCRIPTION
ssr 启动 esbuild 的时机应该在 `umi.server.ts` 写完之后，否则会找不到入口点报错。