### PR TITLE
chore: improve style import RegExp

### DIFF
--- a/packages/bundler-vite/src/plugins/autoCSSModule.ts
+++ b/packages/bundler-vite/src/plugins/autoCSSModule.ts
@@ -14,7 +14,7 @@ export default function autoCSSModulePlugin(): Plugin {
        * import style from './style.less';
        */
       const REG_EXP =
-        /(import [a-z]+ from ["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/;
+        /(import[\s\r\n]+(?!\d)[\w$]+[\s\r\n]+from[\s\r\n]+["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/;
 
       if (code.match(REG_EXP)) {
         // The judgment standard of cssModule in vite uses regular matching, add "?module.css" after the path to match successfully, and then cssModule of vite can be used.


### PR DESCRIPTION
改善 style import 正则
e.g.

```js
var codes = [
  `import 0style from "./index.less"`, // ❌
  `import   a__$ from "./style.sass"`, // ✅
  `import _$_ from    "./index.scss"`, // ✅
  `import _0_ from    "./index.styl"`, // ✅
]

var REG_EXP = /(import[\s\r\n]+(?!\d)[\w$]+[\s\r\n]+from[\s\r\n]+["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/

codes.map(c => c.match(REG_EXP))
```