### PR TITLE
fix:error in getting-start

### DIFF
--- a/docs/docs/tutorials/getting-started.md
+++ b/docs/docs/tutorials/getting-started.md
@@ -75,7 +75,7 @@ event - compiled successfully in 1121 ms (388 modules)
 event - MFSU compiled successfully in 1308 ms (875 modules)
 ```
 
-在浏览器里打开 http://localhost:8000/ ，能看到以下界面，
+在浏览器里打开 [http://localhost:8000/](http://localhost:8000/)，能看到以下界面，
 
 ![](https://img.alicdn.com/imgextra/i2/O1CN01ufcj8M1Lpt1yXd8sy_!!6000000001349-2-tps-1372-1298.png)
 

--- a/docs/docs/tutorials/getting-started.md
+++ b/docs/docs/tutorials/getting-started.md
@@ -75,7 +75,7 @@ event - compiled successfully in 1121 ms (388 modules)
 event - MFSU compiled successfully in 1308 ms (875 modules)
 ```
 
-在浏览器里打开 http://localhost:8000/，能看到以下界面，
+在浏览器里打开 http://localhost:8000/ ，能看到以下界面，
 
 ![](https://img.alicdn.com/imgextra/i2/O1CN01ufcj8M1Lpt1yXd8sy_!!6000000001349-2-tps-1372-1298.png)
 


### PR DESCRIPTION
fix:docs/tutorials/getting-started 文档中 localhost:8000 后面会被当成url一部分