### PR TITLE
fix: react is no defined when react16

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -69,8 +69,8 @@ export default (api: IApi) => {
       path: 'Layout.tsx',
       content: `
 import { Link, useLocation, useNavigate, Outlet, useAppData, useRouteData, matchRoutes } from 'umi';
-import { useMemo } from 'react';
-import  {
+import React, { useMemo } from 'react';
+import {
   ProLayout,
 } from "${pkgPath || '@ant-design/pro-layout'}";
 import './Layout.less';


### PR DESCRIPTION
当项目中 react 为 16 版本时，开启layout后，报错”React is not defined“。
仓库中 max demo react 为 18 无这个问题