### PR TITLE
fix(output): allow absolute output path

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import webpack, { Configuration } from '../../compiled/webpack';
 import Config from '../../compiled/webpack-5-chain';
 import {
@@ -102,7 +102,7 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   );
 
   // output
-  const absOutputPath = join(
+  const absOutputPath = resolve(
     opts.cwd,
     userConfig.outputPath || DEFAULT_OUTPUT_PATH,
   );


### PR DESCRIPTION
#944 引伸的问题，保留绝对路径输出 output ，而不是 `join` 。